### PR TITLE
Handle corrupt cache files during writes

### DIFF
--- a/src/provenancekit/services/cache.py
+++ b/src/provenancekit/services/cache.py
@@ -239,7 +239,11 @@ class CacheService:
             mem_entry = self._mem.get(model_id)
         if mem_entry is not None and mem_entry.vocab is not None:
             return entry.model_copy(update={"vocab": mem_entry.vocab})
-        existing = self._load_disk(model_id)
+        try:
+            existing = self._load_disk(model_id)
+        except CacheError as exc:
+            log.warning("cache_vocab_merge_skipped", model_id=model_id, error=str(exc))
+            return entry
         if existing is not None and existing.vocab is not None:
             return entry.model_copy(update={"vocab": existing.vocab})
         return entry

--- a/tests/services/test_cache.py
+++ b/tests/services/test_cache.py
@@ -112,6 +112,23 @@ class TestCacheDisk:
         path.write_text("NOT VALID JSON {{{", encoding="utf-8")
         assert svc.get("bad-model") is None
 
+    def test_put_replaces_corrupt_disk_cache(self, tmp_path: Path) -> None:
+        svc = CacheService(cache_dir=tmp_path)
+        path = svc._cache_path("org/test-model")
+        path.write_text("NOT VALID JSON {{{", encoding="utf-8")
+
+        entry = CachedEntry(
+            model_id="org/test-model",
+            mfi={"model_type": "llama", "arch_hash": "def456"},
+        )
+        svc.put("org/test-model", entry)
+        svc.clear("org/test-model")
+
+        loaded = svc.get("org/test-model")
+        assert loaded is not None
+        assert loaded.mfi == {"model_type": "llama", "arch_hash": "def456"}
+        assert loaded.vocab is None
+
     def test_creates_cache_dir(self, tmp_path: Path) -> None:
         nested = tmp_path / "deep" / "nested" / "cache"
         svc = CacheService(cache_dir=nested)


### PR DESCRIPTION
Found this while poking at the cache failure paths.

`put()` already treats disk write failures as non-fatal, but the vocab merge step reads the existing disk file before the guarded save. If that file is corrupt JSON, `_load_disk()` raises and the new entry never gets a chance to replace it.

This catches that cache read in `_merge_vocab()` and skips vocab preservation when the old file is bad. The next save writes a clean cache file. Added a regression test for the corrupt-file case.

Checks:
- `uv run pytest tests/services/test_cache.py -q`
- `uv run ruff check .`
- `uv run mypy src`

I also tried `uv run pytest -m "not slow" --tb=short -q`; locally it still hits the existing Hugging Face SSL issue in `TestScanIntegration.test_scan_returns_scan_result`, while the rest of the run passed.