### PR TITLE
Updating pyproject to remove force-include

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,6 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/provenancekit"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"src/provenancekit/data" = "provenancekit/data"
-
 [tool.ruff]
 line-length = 88
 target-version = "py312"


### PR DESCRIPTION
## Summary

- Remove redundant `[tool.hatch.build.targets.wheel.force-include]` from `pyproject.toml`. The `packages = ["src/provenancekit"]` directive already includes everything under `src/provenancekit/data/`, so the `force-include` was duplicating 195 files in the wheel ZIP archive. PyPI rejects wheels with duplicate local headers, causing the publish workflow to fail with a `400 Bad Request`.

## Impact
- Fixes PyPI upload (`Duplicate filename in local headers` error)
- Wheel size reduced from 646 KB to 369 KB (no duplicate entries)
- No functional change and all data files are still included in the package