### PR TITLE
Add optional weight canonicalization before Phase 2 similarity signals

### DIFF
--- a/docs/canonicalization.md
+++ b/docs/canonicalization.md
@@ -30,6 +30,25 @@ flag and disabled by default.
 When SciPy is unavailable the assignment falls back to a greedy
 max-matching solver. Pass `--canonicalize-method greedy` to force it.
 
+## Installing the Hungarian solver
+
+SciPy is an *optional* dependency. Install it via the `canonicalization`
+extra to enable the Hungarian assignment path:
+
+```
+pip install cisco-ai-provenance-kit[canonicalization]
+```
+
+or, with uv:
+
+```
+uv sync --extra canonicalization
+```
+
+The Hungarian solver is recommended for any model whose MLP intermediate
+width is ≥ 8192 (most modern LLMs). Without SciPy the greedy fallback is
+used, which is accurate but slower on wide layers.
+
 ## Important: comparison-only output
 
 > Scale normalization operates in a comparison space and is not

--- a/docs/canonicalization.md
+++ b/docs/canonicalization.md
@@ -1,0 +1,107 @@
+# Canonicalization (Comparison-Space Hardening)
+
+ProvenanceKit's weight-level signals (EAS, NLF, LEP, END, WVC) compute
+cosine / correlation scores in raw weight space. Raw weight space is
+*basis-sensitive*: two functionally identical models can produce very
+different scores after a cheap, function-preserving transformation such
+as
+
+* attention-head permutation,
+* MLP/neuron permutation,
+* adjacent-layer (channel-wise) rescaling,
+* layer-norm gamma absorption.
+
+Canonicalization is an optional pre-processing pass that aligns model B
+into model A's basis (heads + channels) and normalizes per-channel
+scales before similarity scoring. It is opt-in via the `--canonicalize`
+flag and disabled by default.
+
+## What it does
+
+| Step | Behaviour |
+|------|-----------|
+| Permutation alignment (attention) | Builds per-head signatures from Q/K/V (and the corresponding columns of the attention-output projection), solves a Hungarian assignment between A and B's heads, and applies the resulting permutation to B's Q/K/V output rows and to O's input columns. |
+| Permutation alignment (MLP) | Builds per-channel signatures from `up_proj` (and `gate_proj` when present) rows together with `down_proj` columns, solves a Hungarian assignment, and applies the permutation to B's `up`, `gate`, and `down` projections. |
+| Scale normalization (`comparison`, default) | Divides every per-channel slice by its L2 norm. Applied independently to A and B. **Non-invertible.** |
+| Scale normalization (`function_preserving`) | Divides W_in by the per-channel norm α and multiplies W_out by α, preserving forward-pass equivalence. Stricter and slower; offered for callers who want to reuse the canonicalized weights. |
+| LayerNorm gamma | Each LayerNorm/RMSNorm gamma vector is unit-normed independently so it cannot dominate cosine similarity once concatenated with other signals. |
+| Stability check | Per-layer cosine before vs after alignment is compared; large jumps surface in `stability_warnings` to flag partially aligned layers, architecture mismatches, or bad tensor mapping. |
+
+When SciPy is unavailable the assignment falls back to a greedy
+max-matching solver. Pass `--canonicalize-method greedy` to force it.
+
+## Important: comparison-only output
+
+> Scale normalization operates in a comparison space and is not
+> function-preserving. The resulting representation is non-invertible
+> and must not be used for inference or model reconstruction.
+
+> This design intentionally trades invertibility for invariance to
+> common evasion strategies (channel rescaling and layer-norm
+> absorption).
+
+The canonicalizer returns `ComparisonView` objects tagged with
+`is_comparison_only=True`. Inference, serialization, or model-export
+code paths should call
+`provenancekit.core.canonicalization.assert_not_comparison_view` on any
+state-dict-shaped input as a runtime guard.
+
+## CLI
+
+```
+provenancekit compare base-model suspect-model --canonicalize --json
+provenancekit compare base-model suspect-model --canonicalize --canonicalize-method greedy
+provenancekit compare base-model suspect-model --canonicalize --no-scale-normalize
+provenancekit compare base-model suspect-model --canonicalize --canonicalize-scale-mode function_preserving
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--canonicalize` | Enable the pass. Off by default. |
+| `--canonicalize-method {hungarian,greedy}` | Assignment solver. `hungarian` requires SciPy. |
+| `--canonicalize-scale-mode {comparison,function_preserving}` | Scale handling. Default is `comparison` (non-invertible). |
+| `--no-scale-normalize` | Skip per-channel scale normalization. |
+| `--no-permutation-align` | Skip head / channel permutation alignment. |
+
+## JSON output additions
+
+When `--canonicalize` is set, `compare`'s JSON output gains a
+`canonicalization` section:
+
+```json
+"canonicalization": {
+  "enabled": true,
+  "method": "hungarian",
+  "scale_mode": "comparison",
+  "non_invertible": true,
+  "layers_aligned": 32,
+  "attention_heads_aligned": 1024,
+  "mlp_channels_aligned": 11008,
+  "scale_normalized": true,
+  "unsupported_layers": [],
+  "stability_warnings": [],
+  "skipped_reason": null
+}
+```
+
+`non_invertible: true` is intentional and not cosmetic. When
+`scale_mode` is `comparison`, downstream consumers must treat the
+canonicalized representation as a comparison artifact only.
+
+## Limitations
+
+Canonicalization reduces false negatives caused by permutation and
+scale symmetries in functionally equivalent weight representations. It
+**does not** prove lineage under distillation, retraining, model
+merging, or behavioral imitation. Treat it as one additional defence
+against trivial obfuscation, not as a behavioral fingerprint.
+
+* Architecture metadata for both models must be compatible (same head
+  count, same head dimension, same intermediate size). When metadata is
+  missing or mismatched, alignment is skipped for that layer and
+  recorded in `unsupported_layers`.
+* Streaming-only loads (very large models) cannot be canonicalized
+  in-place at comparison time; the report is returned with
+  `skipped_reason="state_dict_unavailable"`.
+* Pairwise canonicalization is performed at comparison time. Cached
+  feature bundles remain unchanged so existing cache keys stay valid.

--- a/docs/canonicalization.md
+++ b/docs/canonicalization.md
@@ -81,6 +81,23 @@ provenancekit compare base-model suspect-model --canonicalize --canonicalize-sca
 | `--canonicalize-scale-mode {comparison,function_preserving}` | Scale handling. Default is `comparison` (non-invertible). |
 | `--no-scale-normalize` | Skip per-channel scale normalization. |
 | `--no-permutation-align` | Skip head / channel permutation alignment. |
+| `--canonicalize-max-mlp-width N` | Skip MLP-channel alignment when the intermediate width exceeds `N`. Default `8192`. Pass `0` or a negative value to disable the gate. |
+
+### MLP-width gate
+
+MLP-channel alignment solves an assignment over the intermediate width,
+which is O(n*m) in both memory and time. On LLM-class models the
+intermediate width is large (LLaMA-3-8B uses 14336), so the cost matrix
+alone runs to multiple gigabytes per layer.
+
+By default the canonicalizer gates MLP-channel alignment off for any
+layer whose intermediate width exceeds `8192` (`max_mlp_width`).
+Skipped layers are recorded in `unsupported_layers` with an
+`mlp_width_exceeded` suffix, and attention-head alignment still runs.
+Pass `--canonicalize-max-mlp-width 0` (or set `max_mlp_width=None` on
+`CanonicalizationConfig`) to disable the gate and align MLP layers of
+any width — recommended only with the SciPy Hungarian solver installed,
+since the greedy fallback is slower on wide layers.
 
 ## JSON output additions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ benchmark = [
     "seaborn",
     "ipykernel",
 ]
+canonicalization = [
+    "scipy>=1.10",
+]
 
 [dependency-groups]
 dev = [

--- a/src/provenancekit/cli.py
+++ b/src/provenancekit/cli.py
@@ -123,16 +123,33 @@ def _add_canonicalize_flags(p: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Disable head/MLP permutation alignment within canonicalization.",
     )
+    p.add_argument(
+        "--canonicalize-max-mlp-width",
+        dest="canonicalize_max_mlp_width",
+        type=int,
+        default=8192,
+        help=(
+            "Skip MLP-channel permutation alignment when the intermediate "
+            "width exceeds N channels. The assignment solver is O(N^2) in "
+            "the MLP width, so wide layers are gated off by default (8192). "
+            "Pass 0 or a negative value to disable the gate and align MLP "
+            "layers of any width."
+        ),
+    )
 
 
 def _build_canonicalization(args: argparse.Namespace) -> CanonicalizationConfig:
     """Build a :class:`CanonicalizationConfig` from CLI flags."""
+    raw_width = getattr(args, "canonicalize_max_mlp_width", 8192)
+    # 0 or negative means "no limit" — disable the MLP-width gate.
+    max_mlp_width = raw_width if raw_width is not None and raw_width > 0 else None
     return CanonicalizationConfig(
         enabled=getattr(args, "canonicalize", False),
         align_permutations=not getattr(args, "canonicalize_no_perm", False),
         normalize_scales=not getattr(args, "canonicalize_no_scale", False),
         method=getattr(args, "canonicalize_method", "hungarian"),
         scale_mode=getattr(args, "canonicalize_scale_mode", "comparison"),
+        max_mlp_width=max_mlp_width,
     )
 
 

--- a/src/provenancekit/cli.py
+++ b/src/provenancekit/cli.py
@@ -38,6 +38,9 @@ sys.stderr.flush()
 from rich.console import Console  # noqa: E402
 
 from provenancekit.config.settings import Settings  # noqa: E402
+from provenancekit.core.canonicalization import (  # noqa: E402
+    CanonicalizationConfig,
+)
 from provenancekit.core.results.formatters import (  # noqa: E402
     format_json,
     format_plain,
@@ -74,6 +77,63 @@ def _unit_float(value: str) -> float:
     if not 0.0 <= fvalue <= 1.0:
         raise argparse.ArgumentTypeError(f"must be in [0.0, 1.0], got {value}")
     return fvalue
+
+
+def _add_canonicalize_flags(p: argparse.ArgumentParser) -> None:
+    """Attach the shared canonicalization flag group to *p*."""
+    p.add_argument(
+        "--canonicalize",
+        dest="canonicalize",
+        action="store_true",
+        help=(
+            "Apply optional comparison-space weight canonicalization "
+            "(attention-head + MLP-channel alignment, per-channel scale "
+            "normalization) before computing weight-level signals. "
+            "Reduces false negatives from permutation/scale evasions. "
+            "Default scale_mode is 'comparison' and is non-invertible."
+        ),
+    )
+    p.add_argument(
+        "--canonicalize-method",
+        dest="canonicalize_method",
+        choices=["hungarian", "greedy"],
+        default="hungarian",
+        help="Assignment solver for permutation alignment.",
+    )
+    p.add_argument(
+        "--canonicalize-scale-mode",
+        dest="canonicalize_scale_mode",
+        choices=["comparison", "function_preserving"],
+        default="comparison",
+        help=(
+            "Per-channel scale handling. 'comparison' (default) is "
+            "non-invertible. 'function_preserving' preserves the forward "
+            "pass and is stricter / slower."
+        ),
+    )
+    p.add_argument(
+        "--no-scale-normalize",
+        dest="canonicalize_no_scale",
+        action="store_true",
+        help="Disable scale normalization within canonicalization.",
+    )
+    p.add_argument(
+        "--no-permutation-align",
+        dest="canonicalize_no_perm",
+        action="store_true",
+        help="Disable head/MLP permutation alignment within canonicalization.",
+    )
+
+
+def _build_canonicalization(args: argparse.Namespace) -> CanonicalizationConfig:
+    """Build a :class:`CanonicalizationConfig` from CLI flags."""
+    return CanonicalizationConfig(
+        enabled=getattr(args, "canonicalize", False),
+        align_permutations=not getattr(args, "canonicalize_no_perm", False),
+        normalize_scales=not getattr(args, "canonicalize_no_scale", False),
+        method=getattr(args, "canonicalize_method", "hungarian"),
+        scale_mode=getattr(args, "canonicalize_scale_mode", "comparison"),
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -137,6 +197,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Allow execution of model-hosted Python code (config/tokenizer). "
         "Use only with models you trust.",
     )
+    _add_canonicalize_flags(cmp)
 
     scn = sub.add_parser("scan", help="Scan a model against known models")
     scn.add_argument(
@@ -199,6 +260,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Allow execution of model-hosted Python code (config/tokenizer). "
         "Use only with models you trust.",
     )
+    _add_canonicalize_flags(scn)
 
     dl = sub.add_parser(
         "download-deepsignals-fingerprint",
@@ -279,12 +341,14 @@ def _run_compare(args: argparse.Namespace) -> int:
     scanner = ModelProvenanceScanner(settings=settings, cache=cache)
 
     use_json = getattr(args, "output_json", False)
+    canon_cfg = _build_canonicalization(args)
     result = _safe_run(
         _run_with_spinner,
         "Comparing models…",
         scanner.compare,
         args.model_a,
         args.model_b,
+        canonicalization=canon_cfg,
         use_json=use_json,
     )
     if result is None:

--- a/src/provenancekit/core/canonicalization.py
+++ b/src/provenancekit/core/canonicalization.py
@@ -554,12 +554,12 @@ class WeightCanonicalizer:
             return 0
 
         n_heads = arch_meta.get("num_attention_heads")
-        n_kv = arch_meta.get("num_key_value_heads") or n_heads
         head_dim = arch_meta.get("head_dim")
         hidden = arch_meta.get("hidden_size") or q_a.shape[1]
         if n_heads is None:
             report.unsupported_layers.append(f"attn:{q_a_name}:missing_num_heads")
             return 0
+        n_kv = arch_meta.get("num_key_value_heads") or n_heads
         if head_dim is None and hidden:
             head_dim = hidden // max(n_heads, 1)
         if head_dim is None or head_dim <= 0 or n_heads <= 0:
@@ -592,17 +592,24 @@ class WeightCanonicalizer:
 
         # Apply permutation to Q/K/V (output dim) and to O (input dim).
         out_b[roles_b["q"]] = _permute_attention_out(q_b, perm, head_dim)
-        if n_heads == (n_kv or n_heads):
+        if n_heads == n_kv:
             kv_perm = perm
         else:
-            # KV head permutation: collapse Q-head perm into KV-head groups.
-            ratio = n_heads // (n_kv or n_heads)
-            kv_perm_arr = np.array(
-                sorted({perm[i] // ratio for i in range(n_heads)}), dtype=np.int64
-            )
-            if kv_perm_arr.size != (n_kv or n_heads):
-                kv_perm_arr = np.arange(n_kv or n_heads, dtype=np.int64)
-            kv_perm = kv_perm_arr
+            # GQA/MQA: derive the KV-head permutation group-wise. Every Q
+            # head in A-side group ``g`` must map to the same B-side KV
+            # group; otherwise the Q permutation is incompatible with the
+            # KV grouping and the canonicalizer must not claim alignment.
+            ratio = n_heads // n_kv
+            kv_perm = np.empty(n_kv, dtype=np.int64)
+            for g in range(n_kv):
+                targets = {int(perm[g * ratio + r]) // ratio for r in range(ratio)}
+                if len(targets) != 1:
+                    report.unsupported_layers.append(f"attn:{q_a_name}:gqa_group_split")
+                    return 0
+                kv_perm[g] = targets.pop()
+            if sorted(kv_perm.tolist()) != list(range(n_kv)):
+                report.unsupported_layers.append(f"attn:{q_a_name}:gqa_perm_invalid")
+                return 0
         kv_head_count = n_kv or n_heads
         out_b[roles_b["k"]] = _permute_attention_out(k_b, kv_perm, head_dim)
         out_b[roles_b["v"]] = _permute_attention_out(v_b, kv_perm, head_dim)

--- a/src/provenancekit/core/canonicalization.py
+++ b/src/provenancekit/core/canonicalization.py
@@ -284,22 +284,34 @@ def _solve_assignment(
         _, col = _scipy_lsa(cost)
         return np.asarray(col, dtype=np.int64)
 
-    # Greedy fallback: sort every (row, col) pair by cost ascending and
-    # assign whenever both row and column are still free. Guarantees a
+    # Greedy fallback: scan every (row, col) cell in ascending cost order
+    # and assign whenever both row and column are still free. Guarantees a
     # complete permutation since the cost matrix is square.
+    #
+    # The cells are ordered by sorting flat indices rather than building a
+    # list of ``(cost, row, col)`` tuples: the tuple form materialised
+    # ~n*m Python objects (~24 bytes each), which OOMs at LLM MLP widths
+    # (n = intermediate_size). A stable argsort over the flattened float32
+    # cost reproduces the same ordering — ties break by flat index, i.e.
+    # lexicographically by (row, col), exactly as the tuple sort did — at
+    # 4 bytes/cell plus the int index array.
     m = cost.shape[1]
-    triples = [(float(cost[i, j]), i, j) for i in range(n) for j in range(m)]
-    triples.sort()
+    flat = cost.astype(np.float32, copy=False).reshape(-1)
+    order = np.argsort(flat, kind="stable")
     perm = np.full(n, -1, dtype=np.int64)
-    used_cols: set[int] = set()
+    row_used = np.zeros(n, dtype=bool)
+    col_used = np.zeros(m, dtype=bool)
     assigned = 0
-    for _, i, j in triples:
-        if perm[i] == -1 and j not in used_cols:
-            perm[i] = j
-            used_cols.add(j)
-            assigned += 1
-            if assigned == n:
-                break
+    for idx in order:
+        i, j = divmod(int(idx), m)
+        if row_used[i] or col_used[j]:
+            continue
+        perm[i] = j
+        row_used[i] = True
+        col_used[j] = True
+        assigned += 1
+        if assigned == n:
+            break
     assert all(int(p) >= 0 for p in perm), "greedy assignment incomplete"
     return perm
 

--- a/src/provenancekit/core/canonicalization.py
+++ b/src/provenancekit/core/canonicalization.py
@@ -1,0 +1,919 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Comparison-space weight canonicalization for similarity scoring.
+
+This module produces *comparison-only* views of model weights so that
+weight-level provenance signals (EAS, WVC, embedding-anchor cosines) are
+robust to cheap function-preserving evasions:
+
+* attention-head permutation,
+* MLP/neuron permutation,
+* adjacent-layer/channel rescaling,
+* layer-norm gamma absorption.
+
+Scale normalization operates in a comparison space and is not
+function-preserving. The resulting representation is non-invertible and
+must not be used for inference or model reconstruction. This design
+intentionally trades invertibility for invariance to common evasion
+strategies (channel rescaling and layer-norm absorption).
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from collections.abc import Iterator, KeysView, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import numpy as np
+import structlog
+import torch
+
+try:
+    from scipy.optimize import (  # type: ignore[import-untyped]
+        linear_sum_assignment as _scipy_lsa,
+    )
+
+    _HAS_SCIPY = True
+except ImportError:  # pragma: no cover - exercised when scipy is absent
+    _HAS_SCIPY = False
+
+log = structlog.get_logger()
+
+ScaleMode = Literal["comparison", "function_preserving"]
+AlignMethod = Literal["greedy", "hungarian"]
+
+_LAYER_INDEX_RE = re.compile(r"(?:layers?|h|block)\.\s*(\d+)\.")
+
+_ATTN_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "q": ("q_proj", "self.query", ".query.", "wq"),
+    "k": ("k_proj", "self.key", ".key.", "wk"),
+    "v": ("v_proj", "self.value", ".value.", "wv"),
+    "o": ("o_proj", "out_proj", "attention.output.dense", "wo"),
+}
+
+_MLP_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "gate": ("gate_proj",),
+    "up": ("up_proj", "fc1", "dense_h_to_4h", "intermediate.dense", "wi_0", "wi"),
+    "down": ("down_proj", "fc2", "dense_4h_to_h", "output.dense", "wi_1", "wo_mlp"),
+}
+
+
+# ── Public configuration / report types ───────────────────────────
+
+
+@dataclass(frozen=True)
+class CanonicalizationConfig:
+    """Configuration knobs for comparison-space canonicalization.
+
+    Attributes:
+        enabled: Master switch. When ``False``, every helper is a no-op.
+        align_permutations: Enable attention-head and MLP-channel
+            permutation alignment of model B into model A's basis.
+        normalize_scales: Enable per-channel scale normalization of
+            paired linear layers.
+        max_layers: Optional cap on the number of layers processed.
+        head_alignment: Align attention heads when architecture metadata
+            is available.
+        mlp_alignment: Align MLP/intermediate channels.
+        eps: Numerical floor used to guard against division by zero.
+        method: Assignment solver. ``"hungarian"`` uses
+            :func:`scipy.optimize.linear_sum_assignment`; falls back to
+            greedy max-matching when scipy is unavailable.
+        scale_mode: ``"comparison"`` (default) performs per-channel
+            unit-norm normalization independently on each model and is
+            *non-invertible*. ``"function_preserving"`` divides W_in by
+            the channel norm and multiplies W_out by the same factor,
+            preserving the forward pass. The function-preserving form is
+            stricter and slower, and is offered for callers who need to
+            reuse the canonicalized weights downstream.
+    """
+
+    enabled: bool = False
+    align_permutations: bool = True
+    normalize_scales: bool = True
+    max_layers: int | None = None
+    head_alignment: bool = True
+    mlp_alignment: bool = True
+    eps: float = 1e-8
+    method: AlignMethod = "hungarian"
+    scale_mode: ScaleMode = "comparison"
+
+
+@dataclass
+class CanonicalizationReport:
+    """Outcome metadata from a single canonicalization pass."""
+
+    enabled: bool = False
+    method: str = "hungarian"
+    scale_mode: str = "comparison"
+    non_invertible: bool = True
+    layers_aligned: int = 0
+    attention_heads_aligned: int = 0
+    mlp_channels_aligned: int = 0
+    scale_normalized: bool = False
+    unsupported_layers: list[str] = field(default_factory=list)
+    stability_warnings: list[str] = field(default_factory=list)
+    skipped_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise the report as a JSON-friendly dict."""
+        return {
+            "enabled": self.enabled,
+            "method": self.method,
+            "scale_mode": self.scale_mode,
+            "non_invertible": self.non_invertible,
+            "layers_aligned": self.layers_aligned,
+            "attention_heads_aligned": self.attention_heads_aligned,
+            "mlp_channels_aligned": self.mlp_channels_aligned,
+            "scale_normalized": self.scale_normalized,
+            "unsupported_layers": list(self.unsupported_layers),
+            "stability_warnings": list(self.stability_warnings),
+            "skipped_reason": self.skipped_reason,
+        }
+
+
+# ── Comparison-only carriers ──────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CanonicalizedTensor:
+    """Comparison-only tensor view produced by :class:`WeightCanonicalizer`.
+
+    **IMPORTANT** — the wrapped tensor is comparison-only:
+    outputs are NOT function-preserving transformations, MUST NOT be
+    used for inference, serialization, or model export, and scale
+    normalization intentionally discards invertibility to collapse
+    equivalence classes for fingerprinting.
+    """
+
+    tensor: torch.Tensor
+    name: str = ""
+
+    @property
+    def is_comparison_only(self) -> bool:
+        """Marker flag used by runtime guards in inference paths."""
+        return True
+
+
+class ComparisonView(Mapping[str, torch.Tensor]):
+    """A state-dict-like dict tagged as comparison-only, non-invertible.
+
+    The class implements :class:`collections.abc.Mapping` so it can be
+    iterated like a regular ``state_dict`` for similarity-extraction
+    code, while carrying a ``is_comparison_only=True`` flag and the
+    canonicalization report. Inference / model-export paths should call
+    :func:`assert_not_comparison_view` before consuming a state dict.
+    """
+
+    is_comparison_only: bool = True
+
+    def __init__(
+        self,
+        tensors: dict[str, torch.Tensor],
+        report: CanonicalizationReport,
+    ) -> None:
+        """Wrap *tensors* as a comparison-only state-dict view."""
+        self._tensors: dict[str, torch.Tensor] = tensors
+        self.report: CanonicalizationReport = report
+
+    def __getitem__(self, key: str) -> torch.Tensor:
+        """Return the tensor stored under *key*."""
+        return self._tensors[key]
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over tensor names in insertion order."""
+        return iter(self._tensors)
+
+    def __len__(self) -> int:
+        """Return the number of tensors carried by this view."""
+        return len(self._tensors)
+
+    def keys(self) -> KeysView[str]:
+        """Return a ``KeysView`` over tensor names."""
+        return self._tensors.keys()
+
+
+def assert_not_comparison_view(state_dict: Any) -> None:
+    """Runtime guard for code paths that must not see comparison views.
+
+    Raises:
+        RuntimeError: When *state_dict* (or any object) carries the
+            ``is_comparison_only`` marker that the canonicalizer attaches
+            to its outputs. Use this in inference / serialization /
+            export entry points so a comparison view cannot be silently
+            substituted for real weights.
+    """
+    if isinstance(state_dict, CanonicalizedTensor) or getattr(
+        state_dict, "is_comparison_only", False
+    ):
+        raise RuntimeError(
+            "Canonicalized tensors are comparison-only and cannot be used "
+            "outside similarity scoring."
+        )
+
+
+# ── Tensor classification helpers ─────────────────────────────────
+
+
+def _layer_index(name: str) -> int | None:
+    match = _LAYER_INDEX_RE.search(name)
+    return int(match.group(1)) if match else None
+
+
+def _matches_any(name: str, keywords: tuple[str, ...]) -> bool:
+    lower = name.lower()
+    return any(kw in lower for kw in keywords)
+
+
+def _attn_role(name: str) -> str | None:
+    for role, keywords in _ATTN_KEYWORDS.items():
+        if _matches_any(name, keywords):
+            return role
+    return None
+
+
+def _mlp_role(name: str) -> str | None:
+    lower = name.lower()
+    # ``output.dense`` appears both in attention output and in MLP output
+    # in BERT-family models. Disambiguate by checking whether ``intermediate``
+    # appeared in the same prefix path.
+    for role, keywords in _MLP_KEYWORDS.items():
+        if _matches_any(name, keywords):
+            if role == "down" and "attention" in lower and "output" in lower:
+                # attention.output.dense is the attention O projection
+                return None
+            return role
+    return None
+
+
+# ── Solver helpers ────────────────────────────────────────────────
+
+
+def _solve_assignment(
+    cost: np.ndarray,
+    method: AlignMethod,
+) -> np.ndarray:
+    """Return the column permutation that minimises the assignment cost.
+
+    The returned array has length equal to ``cost.shape[0]``; entry ``i``
+    is the column index of B that should be mapped onto A's row ``i``.
+    """
+    n = cost.shape[0]
+    if cost.shape[0] != cost.shape[1]:
+        raise ValueError("assignment requires a square cost matrix")
+
+    if method == "hungarian" and _HAS_SCIPY:
+        _, col = _scipy_lsa(cost)
+        return np.asarray(col, dtype=np.int64)
+
+    # Greedy fallback: repeatedly pick the lowest-cost (row, col) pair.
+    work = cost.astype(np.float64, copy=True)
+    perm = np.full(n, -1, dtype=np.int64)
+    used_rows: set[int] = set()
+    used_cols: set[int] = set()
+    big = float(work.max() + 1.0) if work.size else 1.0
+    for _ in range(n):
+        flat_idx = int(np.argmin(work))
+        r, c = divmod(flat_idx, n)
+        if r in used_rows or c in used_cols:
+            # Belt-and-braces: zero-out used coordinates and retry once.
+            work[r, :] = big
+            work[:, c] = big
+            continue
+        perm[r] = c
+        used_rows.add(r)
+        used_cols.add(c)
+        work[r, :] = big
+        work[:, c] = big
+    return perm
+
+
+def _build_cost_matrix(sigs_a: np.ndarray, sigs_b: np.ndarray) -> np.ndarray:
+    """Compute ``1 - cosine`` between every row of A and every row of B."""
+    a = sigs_a.astype(np.float64, copy=False)
+    b = sigs_b.astype(np.float64, copy=False)
+    a_norm = np.linalg.norm(a, axis=1, keepdims=True) + 1e-12
+    b_norm = np.linalg.norm(b, axis=1, keepdims=True) + 1e-12
+    a_unit = a / a_norm
+    b_unit = b / b_norm
+    sim = a_unit @ b_unit.T
+    cost: np.ndarray = 1.0 - sim
+    return cost
+
+
+# ── Per-channel scale helpers ─────────────────────────────────────
+
+
+def _per_channel_unit_norm(tensor: torch.Tensor, axis: int, eps: float) -> torch.Tensor:
+    """Divide *tensor* by the L2 norm along *axis* (per-channel)."""
+    flat_axis = axis if axis >= 0 else tensor.dim() + axis
+    other_axes = [i for i in range(tensor.dim()) if i != flat_axis]
+    norms = torch.linalg.vector_norm(tensor, dim=other_axes, keepdim=True).clamp(
+        min=eps
+    )
+    result: torch.Tensor = tensor / norms
+    return result
+
+
+def _function_preserving_pair(
+    w_in: torch.Tensor,
+    w_out: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Function-preserving rescale of ``W_in`` (output dim) / ``W_out`` (input dim).
+
+    Uses the per-channel L2 norm of ``W_in`` along its output axis as
+    α; divides ``W_in`` rows by α and multiplies the corresponding
+    columns of ``W_out`` by α. Composition ``W_out @ W_in`` is preserved
+    up to numerical precision. Both tensors are then *also* unit-normed
+    per-channel for comparison.
+    """
+    if w_in.dim() < 2 or w_out.dim() < 2:
+        return w_in, w_out
+    if w_in.shape[0] != w_out.shape[1]:
+        return w_in, w_out
+    alpha = (
+        torch.linalg.vector_norm(w_in, dim=tuple(range(1, w_in.dim())))
+        .clamp(min=eps)
+        .reshape(-1)
+    )
+    new_in = w_in / alpha.reshape((-1,) + (1,) * (w_in.dim() - 1))
+    new_out = w_out * alpha.reshape((1,) * (w_out.dim() - 1) + (-1,))
+    return new_in, new_out
+
+
+# ── Architecture metadata extraction ──────────────────────────────
+
+
+def _resolve_arch_meta(
+    config_a: Any | None,
+    config_b: Any | None,
+) -> dict[str, int | None]:
+    """Collect the architecture fields we need for head/MLP alignment.
+
+    Returns the *intersection* of A and B's hyper-parameters: alignment
+    is only safe when the head and MLP shapes match exactly.
+    """
+
+    def _read(cfg: Any, name: str) -> int | None:
+        if cfg is None:
+            return None
+        val = getattr(cfg, name, None)
+        if val is None:
+            return None
+        try:
+            return int(val)
+        except (TypeError, ValueError):
+            return None
+
+    fields = (
+        "hidden_size",
+        "num_attention_heads",
+        "num_key_value_heads",
+        "head_dim",
+        "intermediate_size",
+    )
+    a_vals = {name: _read(config_a, name) for name in fields}
+    b_vals = {name: _read(config_b, name) for name in fields}
+    out: dict[str, int | None] = {}
+    for name in fields:
+        a, b = a_vals[name], b_vals[name]
+        out[name] = a if a is not None and a == b else None
+    return out
+
+
+# ── Core canonicalizer ────────────────────────────────────────────
+
+
+class WeightCanonicalizer:
+    """Produces comparison-space views of model weights for similarity scoring.
+
+    **IMPORTANT** — comparison-only contract, must not be relaxed:
+    outputs are NOT function-preserving transformations, MUST NOT be
+    used for inference, serialization, or model export, and scale
+    normalization intentionally discards invertibility to collapse
+    equivalence classes for fingerprinting.
+    """
+
+    def __init__(self, config: CanonicalizationConfig) -> None:
+        """Bind a configuration object."""
+        self._config = config
+
+    @property
+    def config(self) -> CanonicalizationConfig:
+        """Active configuration."""
+        return self._config
+
+    # ── Public entry point ────────────────────────────────────────
+
+    def canonicalize_pair(
+        self,
+        state_dict_a: Mapping[str, torch.Tensor],
+        state_dict_b: Mapping[str, torch.Tensor],
+        config_a: Any | None = None,
+        config_b: Any | None = None,
+    ) -> tuple[ComparisonView, ComparisonView, CanonicalizationReport]:
+        """Return comparison-space views for two state dicts.
+
+        Model B is aligned into model A's basis (head and channel
+        permutations). Both models are then independently scale-normalized
+        (per-channel) to collapse cheap rescaling evasions.
+
+        Args:
+            state_dict_a: Reference model's state dict.
+            state_dict_b: Suspect model's state dict.
+            config_a: Optional ``AutoConfig``-like object for model A.
+            config_b: Optional ``AutoConfig``-like object for model B.
+
+        Returns:
+            A tuple ``(comparison_view_a, comparison_view_b, report)``.
+            Both views are :class:`ComparisonView` instances with
+            ``is_comparison_only=True``; passing them to anything other
+            than the similarity-scoring path is a contract violation.
+        """
+        cfg = self._config
+        report = CanonicalizationReport(
+            enabled=cfg.enabled,
+            method=cfg.method,
+            scale_mode=cfg.scale_mode,
+            non_invertible=cfg.scale_mode == "comparison",
+        )
+
+        if not cfg.enabled:
+            report.skipped_reason = "canonicalization_disabled"
+            return (
+                ComparisonView(_clone_state(state_dict_a), report),
+                ComparisonView(_clone_state(state_dict_b), report),
+                report,
+            )
+
+        out_a = _clone_state(state_dict_a)
+        out_b = _clone_state(state_dict_b)
+
+        arch_meta = _resolve_arch_meta(config_a, config_b)
+
+        if cfg.align_permutations:
+            self._align_layers(out_a, out_b, arch_meta, report)
+
+        if cfg.normalize_scales:
+            self._normalize_scales(out_a, report.unsupported_layers)
+            self._normalize_scales(out_b, report.unsupported_layers)
+            report.scale_normalized = True
+
+        return (
+            ComparisonView(out_a, report),
+            ComparisonView(out_b, report),
+            report,
+        )
+
+    # ── Permutation alignment ─────────────────────────────────────
+
+    def _align_layers(
+        self,
+        out_a: dict[str, torch.Tensor],
+        out_b: dict[str, torch.Tensor],
+        arch_meta: dict[str, int | None],
+        report: CanonicalizationReport,
+    ) -> None:
+        cfg = self._config
+        layers_a = _group_by_layer(out_a)
+        layers_b = _group_by_layer(out_b)
+        common = sorted(set(layers_a.keys()) & set(layers_b.keys()))
+        if cfg.max_layers is not None:
+            common = common[: cfg.max_layers]
+
+        for li in common:
+            a_names = layers_a[li]
+            b_names = layers_b[li]
+
+            if cfg.head_alignment:
+                aligned_heads = self._align_attention_heads(
+                    out_a, out_b, a_names, b_names, arch_meta, report
+                )
+                if aligned_heads:
+                    report.attention_heads_aligned += aligned_heads
+                    report.layers_aligned += 1
+
+            if cfg.mlp_alignment:
+                aligned_channels = self._align_mlp_channels(
+                    out_a, out_b, a_names, b_names, arch_meta, report
+                )
+                if aligned_channels:
+                    report.mlp_channels_aligned += aligned_channels
+
+    def _align_attention_heads(
+        self,
+        out_a: dict[str, torch.Tensor],
+        out_b: dict[str, torch.Tensor],
+        a_names: dict[str, list[str]],
+        b_names: dict[str, list[str]],
+        arch_meta: dict[str, int | None],
+        report: CanonicalizationReport,
+    ) -> int:
+        a_attn = a_names.get("attn", [])
+        b_attn = b_names.get("attn", [])
+        if not a_attn or not b_attn:
+            return 0
+
+        raw_a = {role: _first_with_role(a_attn, _attn_role, role) for role in "qkv"}
+        raw_b = {role: _first_with_role(b_attn, _attn_role, role) for role in "qkv"}
+        if not all(raw_a.values()) or not all(raw_b.values()):
+            return 0
+        roles_a: dict[str, str] = {k: v for k, v in raw_a.items() if v is not None}
+        roles_b: dict[str, str] = {k: v for k, v in raw_b.items() if v is not None}
+        if len(roles_a) != 3 or len(roles_b) != 3:
+            return 0
+
+        q_a_name = roles_a["q"]
+        q_a, q_b = out_a[q_a_name], out_b[roles_b["q"]]
+        k_a, k_b = out_a[roles_a["k"]], out_b[roles_b["k"]]
+        v_a, v_b = out_a[roles_a["v"]], out_b[roles_b["v"]]
+
+        # Need 2-D tensors with matching shapes between A and B.
+        if any(t.dim() != 2 for t in (q_a, q_b, k_a, k_b, v_a, v_b)):
+            report.unsupported_layers.append(f"attn:{q_a_name}:non_2d")
+            return 0
+        if q_a.shape != q_b.shape or k_a.shape != k_b.shape or v_a.shape != v_b.shape:
+            report.unsupported_layers.append(f"attn:{q_a_name}:shape_mismatch")
+            return 0
+
+        n_heads = arch_meta.get("num_attention_heads")
+        n_kv = arch_meta.get("num_key_value_heads") or n_heads
+        head_dim = arch_meta.get("head_dim")
+        hidden = arch_meta.get("hidden_size") or q_a.shape[1]
+        if n_heads is None:
+            report.unsupported_layers.append(f"attn:{q_a_name}:missing_num_heads")
+            return 0
+        if head_dim is None and hidden:
+            head_dim = hidden // max(n_heads, 1)
+        if head_dim is None or head_dim <= 0 or n_heads <= 0:
+            report.unsupported_layers.append(f"attn:{q_a_name}:invalid_head_dim")
+            return 0
+        if q_a.shape[0] != n_heads * head_dim:
+            report.unsupported_layers.append(f"attn:{q_a_name}:head_shape_mismatch")
+            return 0
+
+        sigs_a, sigs_b = _attention_signatures(
+            q_a, k_a, v_a, q_b, k_b, v_b, n_heads, head_dim, n_kv or n_heads
+        )
+        if sigs_a is None or sigs_b is None:
+            return 0
+
+        cost = _build_cost_matrix(sigs_a, sigs_b)
+        perm = _solve_assignment(cost, self._config.method)
+
+        # Stability check: average self-cosine before vs after on B.
+        before = float(np.mean(np.diag(1.0 - cost)))
+        # Compute average aligned cosine using perm
+        after_sims = [
+            float(1.0 - cost[i, perm[i]]) for i in range(len(perm)) if perm[i] >= 0
+        ]
+        after = float(np.mean(after_sims)) if after_sims else 0.0
+        if after - before > 0.5:
+            report.stability_warnings.append(
+                f"layer:{q_a_name}:perm_jump:{before:.3f}->{after:.3f}"
+            )
+
+        # Apply permutation to Q/K/V (output dim) and to O (input dim).
+        out_b[roles_b["q"]] = _permute_attention_out(q_b, perm, head_dim)
+        if n_heads == (n_kv or n_heads):
+            kv_perm = perm
+        else:
+            # KV head permutation: collapse Q-head perm into KV-head groups.
+            ratio = n_heads // (n_kv or n_heads)
+            kv_perm_arr = np.array(
+                sorted({perm[i] // ratio for i in range(n_heads)}), dtype=np.int64
+            )
+            if kv_perm_arr.size != (n_kv or n_heads):
+                kv_perm_arr = np.arange(n_kv or n_heads, dtype=np.int64)
+            kv_perm = kv_perm_arr
+        kv_head_count = n_kv or n_heads
+        out_b[roles_b["k"]] = _permute_attention_out(k_b, kv_perm, head_dim)
+        out_b[roles_b["v"]] = _permute_attention_out(v_b, kv_perm, head_dim)
+
+        o_a_name = _first_with_role(a_attn, _attn_role, "o")
+        o_b_name = _first_with_role(b_attn, _attn_role, "o")
+        if o_a_name and o_b_name:
+            o_b = out_b[o_b_name]
+            if o_b.dim() == 2 and o_b.shape[1] == n_heads * head_dim:
+                out_b[o_b_name] = _permute_attention_in(o_b, perm, head_dim)
+            else:
+                report.unsupported_layers.append(f"attn:{o_b_name}:o_shape_mismatch")
+        # Suppress unused-name warning
+        del kv_head_count
+        return n_heads
+
+    def _align_mlp_channels(
+        self,
+        out_a: dict[str, torch.Tensor],
+        out_b: dict[str, torch.Tensor],
+        a_names: dict[str, list[str]],
+        b_names: dict[str, list[str]],
+        arch_meta: dict[str, int | None],
+        report: CanonicalizationReport,
+    ) -> int:
+        a_mlp = a_names.get("mlp", [])
+        b_mlp = b_names.get("mlp", [])
+        if not a_mlp or not b_mlp:
+            return 0
+
+        up_a_name_opt = _first_with_role(a_mlp, _mlp_role, "up")
+        up_b_name_opt = _first_with_role(b_mlp, _mlp_role, "up")
+        down_a_name_opt = _first_with_role(a_mlp, _mlp_role, "down")
+        down_b_name_opt = _first_with_role(b_mlp, _mlp_role, "down")
+        if (
+            up_a_name_opt is None
+            or up_b_name_opt is None
+            or down_a_name_opt is None
+            or down_b_name_opt is None
+        ):
+            return 0
+        up_a_name: str = up_a_name_opt
+        up_b_name: str = up_b_name_opt
+        down_a_name: str = down_a_name_opt
+        down_b_name: str = down_b_name_opt
+
+        up_a, up_b = out_a[up_a_name], out_b[up_b_name]
+        down_a, down_b = out_a[down_a_name], out_b[down_b_name]
+        if any(t.dim() != 2 for t in (up_a, up_b, down_a, down_b)):
+            report.unsupported_layers.append(f"mlp:{up_a_name}:non_2d")
+            return 0
+        if up_a.shape != up_b.shape or down_a.shape != down_b.shape:
+            report.unsupported_layers.append(f"mlp:{up_a_name}:shape_mismatch")
+            return 0
+
+        intermediate = up_a.shape[0]
+        meta_inter = arch_meta.get("intermediate_size")
+        if meta_inter is not None and meta_inter != intermediate:
+            report.unsupported_layers.append(f"mlp:{up_a_name}:intermediate_mismatch")
+            return 0
+        if down_a.shape[1] != intermediate:
+            report.unsupported_layers.append(f"mlp:{up_a_name}:down_shape_mismatch")
+            return 0
+
+        gate_a_name = _first_with_role(a_mlp, _mlp_role, "gate")
+        gate_b_name = _first_with_role(b_mlp, _mlp_role, "gate")
+        gate_a = out_a[gate_a_name] if gate_a_name else None
+        gate_b = out_b[gate_b_name] if gate_b_name else None
+
+        sigs_a = _mlp_signatures(up_a, down_a, gate_a)
+        sigs_b = _mlp_signatures(up_b, down_b, gate_b)
+        if sigs_a.shape != sigs_b.shape:
+            return 0
+
+        cost = _build_cost_matrix(sigs_a, sigs_b)
+        perm = _solve_assignment(cost, self._config.method)
+
+        before = float(np.mean(np.diag(1.0 - cost)))
+        after_sims = [
+            float(1.0 - cost[i, perm[i]]) for i in range(len(perm)) if perm[i] >= 0
+        ]
+        after = float(np.mean(after_sims)) if after_sims else 0.0
+        if after - before > 0.5:
+            report.stability_warnings.append(
+                f"layer:{up_a_name}:perm_jump:{before:.3f}->{after:.3f}"
+            )
+
+        perm_t = torch.as_tensor(perm, dtype=torch.long)
+        out_b[up_b_name] = up_b.index_select(0, perm_t).contiguous()
+        out_b[down_b_name] = down_b.index_select(1, perm_t).contiguous()
+        if gate_b_name and gate_b is not None:
+            out_b[gate_b_name] = gate_b.index_select(0, perm_t).contiguous()
+
+        return intermediate
+
+    # ── Scale normalization ───────────────────────────────────────
+
+    def _normalize_scales(
+        self,
+        state: dict[str, torch.Tensor],
+        unsupported: list[str],
+    ) -> None:
+        cfg = self._config
+        layers = _group_by_layer(state)
+
+        for _, names in layers.items():
+            attn = names.get("attn", [])
+            mlp = names.get("mlp", [])
+
+            if cfg.scale_mode == "function_preserving":
+                self._scale_pairs_function_preserving(state, attn, mlp, unsupported)
+            else:
+                self._scale_pairs_comparison(state, attn, mlp)
+
+        # LayerNorm gamma vectors: tag and unit-norm them so they cannot
+        # dominate cosine similarity once concatenated with other signals.
+        for name, tensor in state.items():
+            lower = name.lower()
+            if tensor.dim() == 1 and ("layernorm" in lower or "rmsnorm" in lower):
+                norm = float(torch.linalg.vector_norm(tensor).item())
+                if norm > cfg.eps:
+                    state[name] = tensor / norm
+
+    def _scale_pairs_comparison(
+        self,
+        state: dict[str, torch.Tensor],
+        attn: list[str],
+        mlp: list[str],
+    ) -> None:
+        cfg = self._config
+        # Q/K/V: per-row (output channel) unit-norm.
+        for role in ("q", "k", "v", "o"):
+            name = _first_with_role(attn, _attn_role, role)
+            if not name:
+                continue
+            t = state[name]
+            if t.dim() == 2:
+                axis = 1 if role == "o" else 0
+                state[name] = _per_channel_unit_norm(t, axis=axis, eps=cfg.eps)
+
+        # Gate / up: per-row; down: per-column (input channel).
+        for role in ("gate", "up"):
+            name = _first_with_role(mlp, _mlp_role, role)
+            if not name:
+                continue
+            t = state[name]
+            if t.dim() == 2:
+                state[name] = _per_channel_unit_norm(t, axis=0, eps=cfg.eps)
+
+        down = _first_with_role(mlp, _mlp_role, "down")
+        if down:
+            t = state[down]
+            if t.dim() == 2:
+                state[down] = _per_channel_unit_norm(t, axis=1, eps=cfg.eps)
+
+    def _scale_pairs_function_preserving(
+        self,
+        state: dict[str, torch.Tensor],
+        attn: list[str],
+        mlp: list[str],
+        unsupported: list[str],
+    ) -> None:
+        cfg = self._config
+        # Attention V → O is the canonical adjacent-linear pair.
+        v_name = _first_with_role(attn, _attn_role, "v")
+        o_name = _first_with_role(attn, _attn_role, "o")
+        if v_name and o_name:
+            v_t = state[v_name]
+            o_t = state[o_name]
+            if v_t.dim() == 2 and o_t.dim() == 2 and v_t.shape[0] == o_t.shape[1]:
+                v_t, o_t = _function_preserving_pair(v_t, o_t, cfg.eps)
+                state[v_name] = v_t
+                state[o_name] = o_t
+            else:
+                unsupported.append(f"attn_pair:{v_name}|{o_name}")
+
+        up_name = _first_with_role(mlp, _mlp_role, "up")
+        down_name = _first_with_role(mlp, _mlp_role, "down")
+        if up_name and down_name:
+            u_t = state[up_name]
+            d_t = state[down_name]
+            if u_t.dim() == 2 and d_t.dim() == 2 and u_t.shape[0] == d_t.shape[1]:
+                u_t, d_t = _function_preserving_pair(u_t, d_t, cfg.eps)
+                state[up_name] = u_t
+                state[down_name] = d_t
+            else:
+                unsupported.append(f"mlp_pair:{up_name}|{down_name}")
+
+
+# ── Internal helpers ──────────────────────────────────────────────
+
+
+def _clone_state(state: Mapping[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Return a shallow-clone dict (tensors are detached & cloned)."""
+    out: dict[str, torch.Tensor] = {}
+    for k, v in state.items():
+        if isinstance(v, torch.Tensor):
+            out[k] = v.detach().clone()
+        else:  # pragma: no cover - defensive
+            out[k] = v
+    return out
+
+
+def _group_by_layer(
+    state: Mapping[str, torch.Tensor],
+) -> dict[int, dict[str, list[str]]]:
+    """Group tensor names by layer index and broad role (attn/mlp)."""
+    groups: dict[int, dict[str, list[str]]] = defaultdict(
+        lambda: {"attn": [], "mlp": []}
+    )
+    for name in state:
+        li = _layer_index(name)
+        if li is None:
+            continue
+        if _attn_role(name) is not None:
+            groups[li]["attn"].append(name)
+        elif _mlp_role(name) is not None:
+            groups[li]["mlp"].append(name)
+    return groups
+
+
+def _first_with_role(
+    names: list[str],
+    classifier: Any,
+    role: str,
+) -> str | None:
+    """Return the first *names* entry whose ``classifier`` returns *role*."""
+    for n in names:
+        if classifier(n) == role:
+            return n
+    return None
+
+
+def _attention_signatures(
+    q_a: torch.Tensor,
+    k_a: torch.Tensor,
+    v_a: torch.Tensor,
+    q_b: torch.Tensor,
+    k_b: torch.Tensor,
+    v_b: torch.Tensor,
+    n_heads: int,
+    head_dim: int,
+    n_kv: int,
+) -> tuple[np.ndarray | None, np.ndarray | None]:
+    """Build per-head signature matrices for assignment cost scoring."""
+    if n_heads <= 0 or head_dim <= 0:
+        return None, None
+
+    def _split(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> np.ndarray:
+        q_view = q.reshape(n_heads, head_dim, -1).reshape(n_heads, -1)
+        # KV may have fewer heads under GQA: tile or slice to n_heads.
+        if k.shape[0] == n_heads * head_dim:
+            k_view = k.reshape(n_heads, head_dim, -1).reshape(n_heads, -1)
+            v_view = v.reshape(n_heads, head_dim, -1).reshape(n_heads, -1)
+        elif k.shape[0] == n_kv * head_dim and n_kv > 0 and n_heads % n_kv == 0:
+            ratio = n_heads // n_kv
+            k_view = (
+                k.reshape(n_kv, head_dim, -1)
+                .repeat_interleave(ratio, dim=0)
+                .reshape(n_heads, -1)
+            )
+            v_view = (
+                v.reshape(n_kv, head_dim, -1)
+                .repeat_interleave(ratio, dim=0)
+                .reshape(n_heads, -1)
+            )
+        else:
+            return q_view.float().cpu().numpy()
+        cat = torch.cat([q_view, k_view, v_view], dim=1)
+        return cat.float().cpu().numpy()
+
+    return _split(q_a, k_a, v_a), _split(q_b, k_b, v_b)
+
+
+def _mlp_signatures(
+    up: torch.Tensor,
+    down: torch.Tensor,
+    gate: torch.Tensor | None,
+) -> np.ndarray:
+    """Per-channel MLP signature combining up/gate rows with down columns."""
+    sigs = [up.float()]
+    if gate is not None and gate.shape == up.shape:
+        sigs.append(gate.float())
+    # Down's columns are intermediate channels — transpose so each row is one channel.
+    sigs.append(down.float().t())
+    cat = torch.cat(sigs, dim=1)
+    return cat.cpu().numpy()
+
+
+def _permute_attention_out(
+    tensor: torch.Tensor, perm: np.ndarray, head_dim: int
+) -> torch.Tensor:
+    """Permute output-dim heads of an attention projection (rows)."""
+    n_heads = tensor.shape[0] // head_dim
+    if perm.shape[0] != n_heads:
+        # Mismatched perm — leave tensor unchanged.
+        return tensor
+    perm_t = torch.as_tensor(perm, dtype=torch.long)
+    reshaped = tensor.reshape(n_heads, head_dim, *tensor.shape[1:])
+    permuted = reshaped.index_select(0, perm_t)
+    return permuted.reshape(n_heads * head_dim, *tensor.shape[1:]).contiguous()
+
+
+def _permute_attention_in(
+    tensor: torch.Tensor, perm: np.ndarray, head_dim: int
+) -> torch.Tensor:
+    """Permute input-dim heads of the attention output projection (cols)."""
+    n_heads = tensor.shape[1] // head_dim
+    if perm.shape[0] != n_heads:
+        return tensor
+    perm_t = torch.as_tensor(perm, dtype=torch.long)
+    reshaped = tensor.reshape(tensor.shape[0], n_heads, head_dim)
+    permuted = reshaped.index_select(1, perm_t)
+    return permuted.reshape(tensor.shape[0], n_heads * head_dim).contiguous()

--- a/src/provenancekit/core/canonicalization.py
+++ b/src/provenancekit/core/canonicalization.py
@@ -277,30 +277,30 @@ def _solve_assignment(
     n = cost.shape[0]
     if cost.shape[0] != cost.shape[1]:
         raise ValueError("assignment requires a square cost matrix")
+    if not np.isfinite(cost).all():
+        raise ValueError("cost matrix must contain only finite values")
 
     if method == "hungarian" and _HAS_SCIPY:
         _, col = _scipy_lsa(cost)
         return np.asarray(col, dtype=np.int64)
 
-    # Greedy fallback: repeatedly pick the lowest-cost (row, col) pair.
-    work = cost.astype(np.float64, copy=True)
+    # Greedy fallback: sort every (row, col) pair by cost ascending and
+    # assign whenever both row and column are still free. Guarantees a
+    # complete permutation since the cost matrix is square.
+    m = cost.shape[1]
+    triples = [(float(cost[i, j]), i, j) for i in range(n) for j in range(m)]
+    triples.sort()
     perm = np.full(n, -1, dtype=np.int64)
-    used_rows: set[int] = set()
     used_cols: set[int] = set()
-    big = float(work.max() + 1.0) if work.size else 1.0
-    for _ in range(n):
-        flat_idx = int(np.argmin(work))
-        r, c = divmod(flat_idx, n)
-        if r in used_rows or c in used_cols:
-            # Belt-and-braces: zero-out used coordinates and retry once.
-            work[r, :] = big
-            work[:, c] = big
-            continue
-        perm[r] = c
-        used_rows.add(r)
-        used_cols.add(c)
-        work[r, :] = big
-        work[:, c] = big
+    assigned = 0
+    for _, i, j in triples:
+        if perm[i] == -1 and j not in used_cols:
+            perm[i] = j
+            used_cols.add(j)
+            assigned += 1
+            if assigned == n:
+                break
+    assert all(int(p) >= 0 for p in perm), "greedy assignment incomplete"
     return perm
 
 

--- a/src/provenancekit/core/canonicalization.py
+++ b/src/provenancekit/core/canonicalization.py
@@ -305,15 +305,22 @@ def _solve_assignment(
 
 
 def _build_cost_matrix(sigs_a: np.ndarray, sigs_b: np.ndarray) -> np.ndarray:
-    """Compute ``1 - cosine`` between every row of A and every row of B."""
-    a = sigs_a.astype(np.float64, copy=False)
-    b = sigs_b.astype(np.float64, copy=False)
+    """Compute ``1 - cosine`` between every row of A and every row of B.
+
+    The cost matrix is built in ``float32`` rather than the NumPy default
+    ``float64``. This halves peak memory of the assignment step, which is
+    O(n*m) and dominates on LLM-width MLP layers (n = intermediate_size).
+    The precision loss is immaterial: the matrix holds cosine distances
+    consumed by a permutation solver, not values carried into scoring.
+    """
+    a = sigs_a.astype(np.float32, copy=False)
+    b = sigs_b.astype(np.float32, copy=False)
     a_norm = np.linalg.norm(a, axis=1, keepdims=True) + 1e-12
     b_norm = np.linalg.norm(b, axis=1, keepdims=True) + 1e-12
     a_unit = a / a_norm
     b_unit = b / b_norm
     sim = a_unit @ b_unit.T
-    cost: np.ndarray = 1.0 - sim
+    cost: np.ndarray = (1.0 - sim).astype(np.float32, copy=False)
     return cost
 
 

--- a/src/provenancekit/core/canonicalization.py
+++ b/src/provenancekit/core/canonicalization.py
@@ -590,8 +590,10 @@ class WeightCanonicalizer:
                 f"layer:{q_a_name}:perm_jump:{before:.3f}->{after:.3f}"
             )
 
-        # Apply permutation to Q/K/V (output dim) and to O (input dim).
-        out_b[roles_b["q"]] = _permute_attention_out(q_b, perm, head_dim)
+        # Derive the KV-head permutation *before* mutating ``out_b``. A
+        # GQA group-split bail must leave the comparison views byte-for-byte
+        # untouched; permuting Q up-front would silently reorder B's q_proj
+        # while the report still claims nothing was aligned.
         if n_heads == n_kv:
             kv_perm = perm
         else:
@@ -610,7 +612,10 @@ class WeightCanonicalizer:
             if sorted(kv_perm.tolist()) != list(range(n_kv)):
                 report.unsupported_layers.append(f"attn:{q_a_name}:gqa_perm_invalid")
                 return 0
-        kv_head_count = n_kv or n_heads
+
+        # All permutations validated — apply to Q/K/V (output dim) and to
+        # O (input dim).
+        out_b[roles_b["q"]] = _permute_attention_out(q_b, perm, head_dim)
         out_b[roles_b["k"]] = _permute_attention_out(k_b, kv_perm, head_dim)
         out_b[roles_b["v"]] = _permute_attention_out(v_b, kv_perm, head_dim)
 
@@ -622,8 +627,6 @@ class WeightCanonicalizer:
                 out_b[o_b_name] = _permute_attention_in(o_b, perm, head_dim)
             else:
                 report.unsupported_layers.append(f"attn:{o_b_name}:o_shape_mismatch")
-        # Suppress unused-name warning
-        del kv_head_count
         return n_heads
 
     def _align_mlp_channels(

--- a/src/provenancekit/core/canonicalization.py
+++ b/src/provenancekit/core/canonicalization.py
@@ -91,6 +91,12 @@ class CanonicalizationConfig:
         head_alignment: Align attention heads when architecture metadata
             is available.
         mlp_alignment: Align MLP/intermediate channels.
+        max_mlp_width: Skip MLP-channel permutation alignment when the
+            intermediate width exceeds this many channels. The assignment
+            solver is O(n*m) in the intermediate width, so wide layers
+            are gated off by default (8192) and recorded in
+            ``unsupported_layers``. ``None`` disables the gate and aligns
+            MLP layers of any width.
         eps: Numerical floor used to guard against division by zero.
         method: Assignment solver. ``"hungarian"`` uses
             :func:`scipy.optimize.linear_sum_assignment`; falls back to
@@ -110,6 +116,7 @@ class CanonicalizationConfig:
     max_layers: int | None = None
     head_alignment: bool = True
     mlp_alignment: bool = True
+    max_mlp_width: int | None = 8192
     eps: float = 1e-8
     method: AlignMethod = "hungarian"
     scale_mode: ScaleMode = "comparison"
@@ -688,6 +695,14 @@ class WeightCanonicalizer:
             return 0
 
         intermediate = up_a.shape[0]
+        max_width = self._config.max_mlp_width
+        if max_width is not None and intermediate > max_width:
+            # The assignment cost matrix and its solve are O(n*m) in the
+            # intermediate width. Gate wide MLP layers off rather than
+            # build a multi-GB cost matrix; record the skip so callers
+            # can see alignment was not attempted for this block.
+            report.unsupported_layers.append(f"mlp:{up_a_name}:mlp_width_exceeded")
+            return 0
         meta_inter = arch_meta.get("intermediate_size")
         if meta_inter is not None and meta_inter != intermediate:
             report.unsupported_layers.append(f"mlp:{up_a_name}:intermediate_mismatch")

--- a/src/provenancekit/core/scanner.py
+++ b/src/provenancekit/core/scanner.py
@@ -34,6 +34,11 @@ from huggingface_hub import model_info
 from transformers import AutoTokenizer
 
 from provenancekit.config.settings import Settings
+from provenancekit.core.canonicalization import (
+    CanonicalizationConfig,
+    CanonicalizationReport,
+    WeightCanonicalizer,
+)
 from provenancekit.core.lookup import run_lookup
 from provenancekit.core.scoring import (
     compute_identity_score,
@@ -64,6 +69,7 @@ from provenancekit.core.signals.weight_signals import (
 from provenancekit.exceptions import ExtractionError, ModelLoadError
 from provenancekit.models.results import (
     CachedEntry,
+    CanonicalizationReportOutput,
     CompareResult,
     LoadStrategy,
     PipelineScore,
@@ -99,6 +105,12 @@ class _ModelData:
     mfi_cache_hit: bool
     tfv_cache_hit: bool
     ws_cache_hit: bool
+    # Populated only when canonicalization is requested. Holds the raw
+    # state-dict and the originating ``AutoConfig`` so the comparison-time
+    # canonicalizer can permute heads / channels and renormalize before
+    # weight signals are recomputed. Discarded after canonicalization.
+    state_dict: dict[str, Any] | None = None
+    config: Any | None = None
 
 
 class ModelProvenanceScanner:
@@ -152,17 +164,28 @@ class ModelProvenanceScanner:
         model_b: str,
         *,
         on_phase: Callable[[str], None] | None = None,
+        canonicalization: CanonicalizationConfig | None = None,
     ) -> CompareResult:
-        """Compare two models and return a detailed provenance result."""
+        """Compare two models and return a detailed provenance result.
+
+        When *canonicalization* is provided and ``enabled``, weight-level
+        signals (EAS, NLF, LEP, END, WVC) are recomputed from a
+        comparison-space view that aligns attention heads / MLP channels
+        and normalizes per-channel scales. The canonicalized
+        representation is non-invertible (with the default
+        ``scale_mode="comparison"``) and is not used for caching.
+        """
         _phase = on_phase or (lambda _msg: None)
 
         t0 = time.monotonic()
         log.info("compare_start", model_a=model_a, model_b=model_b)
 
+        canon_cfg = canonicalization or CanonicalizationConfig()
+
         _phase("extracting features from model A")
         t_extract_a = time.monotonic()
         log.info("extract_start", model_id=model_a)
-        data_a = self._extract_model(model_a)
+        data_a = self._extract_model(model_a, canonicalize=canon_cfg.enabled)
         extract_a_elapsed = time.monotonic() - t_extract_a
         log.info(
             "extract_done",
@@ -173,13 +196,20 @@ class ModelProvenanceScanner:
         _phase("extracting features from model B")
         t_extract_b = time.monotonic()
         log.info("extract_start", model_id=model_b)
-        data_b = self._extract_model(model_b)
+        data_b = self._extract_model(model_b, canonicalize=canon_cfg.enabled)
         extract_b_elapsed = time.monotonic() - t_extract_b
         log.info(
             "extract_done",
             model_id=model_b,
             elapsed=f"{extract_b_elapsed:.1f}s",
         )
+
+        canon_report: CanonicalizationReport | None = None
+        if canon_cfg.enabled:
+            _phase("canonicalizing comparison views")
+            data_a, data_b, canon_report = self._canonicalize_pair(
+                data_a, data_b, canon_cfg
+            )
 
         _phase("computing similarity scores")
         t_score = time.monotonic()
@@ -246,6 +276,19 @@ class ModelProvenanceScanner:
             scoring_elapsed=f"{scoring_elapsed:.1f}s",
         )
 
+        canon_output: CanonicalizationReportOutput | None = None
+        if canon_cfg.enabled:
+            source_report = canon_report or CanonicalizationReport(
+                enabled=True,
+                method=canon_cfg.method,
+                scale_mode=canon_cfg.scale_mode,
+                non_invertible=canon_cfg.scale_mode == "comparison",
+                skipped_reason="no_tensors_available",
+            )
+            canon_output = CanonicalizationReportOutput(
+                **source_report.to_dict()
+            )
+
         return CompareResult(
             model_a=model_a,
             model_b=model_b,
@@ -277,6 +320,7 @@ class ModelProvenanceScanner:
                 weight_feature_extract_seconds=round(weight_feature_extract_elapsed, 3),
                 cache_hit=cache_hit,
             ),
+            canonicalization=canon_output,
         )
 
     def scan(
@@ -398,8 +442,17 @@ class ModelProvenanceScanner:
             self._db_service = DatabaseService(self._settings.db_root)
         return self._db_service
 
-    def _extract_model(self, model_id: str) -> _ModelData:
-        """Extract all features for a single model, with caching."""
+    def _extract_model(
+        self, model_id: str, *, canonicalize: bool = False
+    ) -> _ModelData:
+        """Extract all features for a single model, with caching.
+
+        When *canonicalize* is true, the raw ``state_dict`` and
+        ``AutoConfig`` are retained on the returned bundle so that the
+        comparison-time canonicalizer can recompute weight signals from
+        a comparison-space view. Cached weight signals are bypassed in
+        that path because canonicalization mutates per-channel scales.
+        """
         model_id = model_id.strip()
         cached = self._cache.get(model_id)
 
@@ -413,7 +466,17 @@ class ModelProvenanceScanner:
 
         t_ws = time.monotonic()
         ws: WeightSignalFeatures | None
-        if ws_cache_hit and cached is not None and cached.ws is not None:
+        state_dict: dict[str, Any] | None = None
+        cfg_obj: Any | None = None
+
+        if canonicalize:
+            # Bypass the cached weight signals: canonicalization needs raw
+            # tensors, and cached features are summaries.
+            ws_cache_hit = False
+            ws, state_dict, cfg_obj = self._extract_weight_signals_with_state(
+                model_id, tokenizer
+            )
+        elif ws_cache_hit and cached is not None and cached.ws is not None:
             log.info("cache_hit_ws", model_id=model_id)
             ws = WeightSignalFeatures.from_cache_dict(cached.ws)
         else:
@@ -443,7 +506,138 @@ class ModelProvenanceScanner:
             mfi_cache_hit=mfi_cache_hit,
             tfv_cache_hit=tfv_cache_hit,
             ws_cache_hit=ws_cache_hit,
+            state_dict=state_dict,
+            config=cfg_obj,
         )
+
+    def _extract_weight_signals_with_state(
+        self, model_id: str, tokenizer: Any
+    ) -> tuple[WeightSignalFeatures | None, dict[str, Any] | None, Any | None]:
+        """Variant of :meth:`_extract_weight_signals` that retains the state dict.
+
+        Used by the canonicalization path. When the loader returns a
+        ``streaming`` strategy, the state dict is unavailable and the
+        method falls back to a normal streaming extraction with no
+        retained tensors.
+        """
+        log.info("weight_load_start", model_id=model_id)
+        try:
+            result = load_state_dict(model_id, settings=self._settings)
+        except ModelLoadError as exc:
+            log.warning("model_load_failed", model_id=model_id, error=str(exc))
+            return None, None, None
+
+        vocab = self._get_vocab(tokenizer)
+        try:
+            if result.strategy == LoadStrategy.full and result.state_dict is not None:
+                ws = extract_signals(
+                    result.state_dict,
+                    result.config,
+                    tokenizer=tokenizer,
+                    vocab=vocab,
+                    settings=self._settings,
+                )
+                return ws, result.state_dict, result.config
+            if result.strategy == LoadStrategy.streaming:
+                ws = extract_signals_streaming(
+                    model_id,
+                    tokenizer=tokenizer,
+                    vocab=vocab,
+                    settings=self._settings,
+                )
+                log.warning(
+                    "canonicalize_streaming_skipped",
+                    model_id=model_id,
+                    reason="state_dict_unavailable",
+                )
+                return ws, None, result.config
+        except ExtractionError as exc:
+            log.warning("signal_extraction_failed", model_id=model_id, error=str(exc))
+            return None, None, None
+        return None, None, None
+
+    def _canonicalize_pair(
+        self,
+        data_a: _ModelData,
+        data_b: _ModelData,
+        canon_cfg: CanonicalizationConfig,
+    ) -> tuple[_ModelData, _ModelData, CanonicalizationReport | None]:
+        """Apply canonicalization to a paired ``_ModelData`` bundle.
+
+        Returns updated copies of the two bundles whose ``ws`` field has
+        been recomputed from the comparison-space views, plus the
+        canonicalization report. When state dicts are unavailable for
+        either model (e.g. streaming-only loads), canonicalization is
+        skipped and the original ``ws`` values are preserved.
+        """
+        if data_a.state_dict is None or data_b.state_dict is None:
+            log.warning(
+                "canonicalization_skipped",
+                reason="state_dict_unavailable",
+                model_a_has=data_a.state_dict is not None,
+                model_b_has=data_b.state_dict is not None,
+            )
+            report = CanonicalizationReport(
+                enabled=True,
+                method=canon_cfg.method,
+                scale_mode=canon_cfg.scale_mode,
+                non_invertible=canon_cfg.scale_mode == "comparison",
+                skipped_reason="state_dict_unavailable",
+            )
+            return data_a, data_b, report
+
+        canonicalizer = WeightCanonicalizer(canon_cfg)
+        view_a, view_b, report = canonicalizer.canonicalize_pair(
+            data_a.state_dict,
+            data_b.state_dict,
+            config_a=data_a.config,
+            config_b=data_b.config,
+        )
+
+        vocab_a = self._get_vocab(data_a.tokenizer)
+        vocab_b = self._get_vocab(data_b.tokenizer)
+        ws_a = extract_signals(
+            dict(view_a),
+            data_a.config,
+            tokenizer=data_a.tokenizer,
+            vocab=vocab_a,
+            settings=self._settings,
+        )
+        ws_b = extract_signals(
+            dict(view_b),
+            data_b.config,
+            tokenizer=data_b.tokenizer,
+            vocab=vocab_b,
+            settings=self._settings,
+        )
+
+        new_a = _ModelData(
+            fp=data_a.fp,
+            tfv=data_a.tfv,
+            ws=ws_a,
+            tokenizer=data_a.tokenizer,
+            base_elapsed=data_a.base_elapsed,
+            weight_elapsed=data_a.weight_elapsed,
+            mfi_cache_hit=data_a.mfi_cache_hit,
+            tfv_cache_hit=data_a.tfv_cache_hit,
+            ws_cache_hit=data_a.ws_cache_hit,
+            state_dict=None,
+            config=data_a.config,
+        )
+        new_b = _ModelData(
+            fp=data_b.fp,
+            tfv=data_b.tfv,
+            ws=ws_b,
+            tokenizer=data_b.tokenizer,
+            base_elapsed=data_b.base_elapsed,
+            weight_elapsed=data_b.weight_elapsed,
+            mfi_cache_hit=data_b.mfi_cache_hit,
+            tfv_cache_hit=data_b.tfv_cache_hit,
+            ws_cache_hit=data_b.ws_cache_hit,
+            state_dict=None,
+            config=data_b.config,
+        )
+        return new_a, new_b, report
 
     def _extract_base(
         self,

--- a/src/provenancekit/core/scanner.py
+++ b/src/provenancekit/core/scanner.py
@@ -285,9 +285,7 @@ class ModelProvenanceScanner:
                 non_invertible=canon_cfg.scale_mode == "comparison",
                 skipped_reason="no_tensors_available",
             )
-            canon_output = CanonicalizationReportOutput(
-                **source_report.to_dict()
-            )
+            canon_output = CanonicalizationReportOutput(**source_report.to_dict())
 
         return CompareResult(
             model_a=model_a,

--- a/src/provenancekit/models/results.py
+++ b/src/provenancekit/models/results.py
@@ -32,7 +32,7 @@ Scoring recap::
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 # ── Model loading result ──────────────────────────────────────────
 
@@ -125,8 +125,8 @@ class CanonicalizationReportOutput(BaseModel):
     attention_heads_aligned: int = 0
     mlp_channels_aligned: int = 0
     scale_normalized: bool = False
-    unsupported_layers: list[str] = []
-    stability_warnings: list[str] = []
+    unsupported_layers: list[str] = Field(default_factory=list)
+    stability_warnings: list[str] = Field(default_factory=list)
     skipped_reason: str | None = None
 
 

--- a/src/provenancekit/models/results.py
+++ b/src/provenancekit/models/results.py
@@ -109,6 +109,27 @@ class TimingBreakdown(BaseModel):
     cache_hit: str
 
 
+class CanonicalizationReportOutput(BaseModel):
+    """JSON-friendly canonicalization metadata attached to ``CompareResult``.
+
+    ``non_invertible`` is intentionally exposed: when ``scale_mode`` is
+    ``"comparison"`` (default) the canonicalized representation cannot be
+    used for inference or model reconstruction.
+    """
+
+    enabled: bool
+    method: str
+    scale_mode: str
+    non_invertible: bool
+    layers_aligned: int = 0
+    attention_heads_aligned: int = 0
+    mlp_channels_aligned: int = 0
+    scale_normalized: bool = False
+    unsupported_layers: list[str] = []
+    stability_warnings: list[str] = []
+    skipped_reason: str | None = None
+
+
 class CompareResult(BaseModel):
     """Full top-level comparison output for a model pair.
 
@@ -125,6 +146,7 @@ class CompareResult(BaseModel):
     interpretation: ScoreInterpretation
     time_seconds: float
     timing: TimingBreakdown | None = None
+    canonicalization: CanonicalizationReportOutput | None = None
 
 
 class CachedEntry(BaseModel):

--- a/tests/test_canonicalization.py
+++ b/tests/test_canonicalization.py
@@ -870,7 +870,7 @@ class TestGQAKVPermutation:
             method="hungarian",
         )
         canonicalizer = WeightCanonicalizer(cfg)
-        _, _, report = canonicalizer.canonicalize_pair(
+        _, view_b, report = canonicalizer.canonicalize_pair(
             state_a, state_b, cfg_meta, cfg_meta
         )
 
@@ -880,6 +880,16 @@ class TestGQAKVPermutation:
         assert any(
             entry.endswith(":gqa_group_split") for entry in report.unsupported_layers
         ), report.unsupported_layers
+
+        # Bailing must leave B's comparison view byte-identical to the input.
+        # The Q permutation used to be applied before the KV-group check, so
+        # a group-split bail silently reordered q_proj while the report still
+        # claimed ``attention_heads_aligned == 0`` — an inconsistent view.
+        for role in ("q_proj", "k_proj", "v_proj", "o_proj"):
+            name = f"model.layers.0.self_attn.{role}.weight"
+            assert torch.equal(view_b[name], state_b[name]), (
+                f"{role} mutated despite gqa_group_split bail"
+            )
 
     def test_mqa_single_kv_group_handles_trivial_permutation(self) -> None:
         rng = np.random.default_rng(9)

--- a/tests/test_canonicalization.py
+++ b/tests/test_canonicalization.py
@@ -28,6 +28,7 @@ Synthetic transformer-like state dicts validate:
 
 from __future__ import annotations
 
+import argparse
 import contextlib
 import sys
 from dataclasses import dataclass
@@ -37,6 +38,7 @@ import numpy as np
 import pytest
 import torch
 
+from provenancekit.cli import _build_canonicalization
 from provenancekit.cli import main as cli_main
 from provenancekit.core.canonicalization import (
     _HAS_SCIPY,
@@ -1095,3 +1097,163 @@ class TestVectorizedGreedy:
         recovered = _solve_assignment(cost, method="greedy")
         _assert_complete_perm(recovered, n)
         assert recovered.tolist() == perm.tolist()
+
+
+# ── MLP-width threshold gate coverage (Fix 4) ─────────────────────
+
+
+class TestMLPWidthThreshold:
+    """Lock the ``max_mlp_width`` gate on MLP-channel alignment.
+
+    MLP-channel alignment is O(n*m) in the intermediate width. The gate
+    skips alignment for layers wider than ``max_mlp_width`` (default
+    8192) and records the skip in ``unsupported_layers``; ``None``
+    disables the gate.
+    """
+
+    def test_mlp_width_threshold_default_skips_wide_layer(self) -> None:
+        # An LLaMA-3-8B-width MLP layer (intermediate 14336). The default
+        # gate (8192) must skip alignment without building the cost
+        # matrix and record an ``mlp_width_exceeded`` entry.
+        rng = np.random.default_rng(31)
+        hidden, intermediate = 16, 14336
+        state_a = _make_mlp_layer(rng, hidden, intermediate)
+        perm = np.random.default_rng(32).permutation(intermediate)
+        state_b = _permute_mlp_b(state_a, perm)
+
+        cfg = CanonicalizationConfig(
+            enabled=True,
+            align_permutations=True,
+            normalize_scales=False,
+        )
+        assert cfg.max_mlp_width == 8192  # default
+
+        view_a, view_b, report = WeightCanonicalizer(cfg).canonicalize_pair(
+            state_a, state_b, None, None
+        )
+
+        assert report.mlp_channels_aligned == 0
+        assert any(
+            entry.endswith(":mlp_width_exceeded") for entry in report.unsupported_layers
+        ), report.unsupported_layers
+        # Alignment skipped: B's projections are byte-identical to input.
+        for role in ("up_proj", "gate_proj", "down_proj"):
+            name = f"model.layers.0.mlp.{role}.weight"
+            assert torch.equal(view_b[name], state_b[name]), (
+                f"{role} mutated despite the mlp_width_exceeded gate"
+            )
+
+    def test_mlp_width_threshold_override_via_config(self) -> None:
+        # An MLP layer wider than a configured threshold: with the
+        # threshold set the layer is gated, and with ``max_mlp_width=None``
+        # the gate is disabled, alignment runs, and the permutation is
+        # recovered with no unsupported entry.
+        #
+        # A modest width with a lowered threshold is used rather than the
+        # full LLaMA-3-8B 14336: with the gate off the test executes the
+        # real O(n*m) alignment solve, and a 14336-wide solve is a
+        # multi-minute operation unfit for the unit suite. The
+        # gate-disabled path at full LLM width is measured by the
+        # standalone scalability harness instead.
+        rng = np.random.default_rng(33)
+        hidden, intermediate = 16, 384
+        state_a = _make_mlp_layer(rng, hidden, intermediate)
+        perm = np.random.default_rng(34).permutation(intermediate)
+        state_b = _permute_mlp_b(state_a, perm)
+
+        # Sanity: a threshold below the layer width gates it off.
+        gated = CanonicalizationConfig(
+            enabled=True,
+            align_permutations=True,
+            normalize_scales=False,
+            max_mlp_width=intermediate // 2,
+        )
+        _, _, gated_report = WeightCanonicalizer(gated).canonicalize_pair(
+            state_a, state_b, None, None
+        )
+        assert gated_report.mlp_channels_aligned == 0
+        assert any(
+            entry.endswith(":mlp_width_exceeded")
+            for entry in gated_report.unsupported_layers
+        )
+
+        # Override: max_mlp_width=None disables the gate entirely.
+        cfg = CanonicalizationConfig(
+            enabled=True,
+            align_permutations=True,
+            normalize_scales=False,
+            method="hungarian",
+            max_mlp_width=None,
+        )
+        view_a, view_b, report = WeightCanonicalizer(cfg).canonicalize_pair(
+            state_a, state_b, None, None
+        )
+
+        assert report.mlp_channels_aligned == intermediate
+        assert report.unsupported_layers == []
+        up_cos = _vec_cosine(
+            view_a["model.layers.0.mlp.up_proj.weight"],
+            view_b["model.layers.0.mlp.up_proj.weight"],
+        )
+        assert up_cos > 0.999, f"override alignment failed (cosine {up_cos:.4f})"
+
+    def test_mlp_width_threshold_allows_layer_at_limit(self) -> None:
+        # A layer exactly at the threshold is not gated (strict ``>``).
+        rng = np.random.default_rng(35)
+        hidden, intermediate = 16, 256
+        state_a = _make_mlp_layer(rng, hidden, intermediate)
+        perm = np.random.default_rng(36).permutation(intermediate)
+        state_b = _permute_mlp_b(state_a, perm)
+
+        cfg = CanonicalizationConfig(
+            enabled=True,
+            align_permutations=True,
+            normalize_scales=False,
+            max_mlp_width=intermediate,
+        )
+        _, _, report = WeightCanonicalizer(cfg).canonicalize_pair(
+            state_a, state_b, None, None
+        )
+        assert report.mlp_channels_aligned == intermediate
+        assert report.unsupported_layers == []
+
+
+class TestMaxMLPWidthCLI:
+    """Lock the ``--canonicalize-max-mlp-width`` CLI flag and its wiring."""
+
+    def test_flag_appears_in_compare_and_scan_help(self) -> None:
+        for cmd in ("compare", "scan"):
+            old_argv = sys.argv
+            old_stdout = sys.stdout
+            buf = StringIO()
+            try:
+                sys.argv = ["provenancekit", cmd, "--help"]
+                sys.stdout = buf
+                with contextlib.suppress(SystemExit):
+                    cli_main()
+            finally:
+                sys.argv = old_argv
+                sys.stdout = old_stdout
+            assert "--canonicalize-max-mlp-width" in buf.getvalue(), cmd
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (8192, 8192),
+            (16384, 16384),
+            (1, 1),
+            (0, None),
+            (-1, None),
+            (-9999, None),
+        ],
+    )
+    def test_build_canonicalization_maps_width(
+        self, raw: int, expected: int | None
+    ) -> None:
+        args = argparse.Namespace(canonicalize_max_mlp_width=raw)
+        cfg = _build_canonicalization(args)
+        assert cfg.max_mlp_width == expected
+
+    def test_default_when_flag_absent(self) -> None:
+        cfg = _build_canonicalization(argparse.Namespace())
+        assert cfg.max_mlp_width == 8192

--- a/tests/test_canonicalization.py
+++ b/tests/test_canonicalization.py
@@ -706,3 +706,217 @@ class TestCanonicalizationReportMutableDefaults:
             field_schema = props[name]
             assert field_schema["type"] == "array"
             assert field_schema["items"] == {"type": "string"}
+
+
+# ── GQA / MQA regression coverage ─────────────────────────────────
+
+
+def _make_gqa_attention_layer(
+    rng: np.random.Generator,
+    hidden: int,
+    n_heads: int,
+    n_kv: int,
+    head_dim: int,
+) -> dict[str, torch.Tensor]:
+    """Build q/k/v/o projections for a grouped-/multi-query attention block.
+
+    K and V carry ``n_kv`` heads (``n_kv * head_dim`` rows) while Q and O
+    carry the full ``n_heads`` — the shape that exercises the KV-head
+    permutation path of ``_align_attention_heads``.
+    """
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv * head_dim
+    q = torch.tensor(rng.standard_normal((q_dim, hidden)), dtype=torch.float32)
+    k = torch.tensor(rng.standard_normal((kv_dim, hidden)), dtype=torch.float32)
+    v = torch.tensor(rng.standard_normal((kv_dim, hidden)), dtype=torch.float32)
+    o = torch.tensor(rng.standard_normal((hidden, q_dim)), dtype=torch.float32)
+    return {
+        "model.layers.0.self_attn.q_proj.weight": q,
+        "model.layers.0.self_attn.k_proj.weight": k,
+        "model.layers.0.self_attn.v_proj.weight": v,
+        "model.layers.0.self_attn.o_proj.weight": o,
+    }
+
+
+def _permute_gqa_attention_b(
+    state: dict[str, torch.Tensor],
+    perm_q: np.ndarray,
+    perm_kv: np.ndarray,
+    head_dim: int,
+    n_heads: int,
+    n_kv: int,
+) -> dict[str, torch.Tensor]:
+    """Apply independent Q-head and KV-head permutations to a GQA block.
+
+    ``perm_q`` permutes the ``n_heads`` Q heads (and the matching O input
+    heads); ``perm_kv`` permutes the ``n_kv`` KV heads of K and V.
+    """
+    out = dict(state)
+    perm_q_t = torch.as_tensor(perm_q, dtype=torch.long)
+    perm_kv_t = torch.as_tensor(perm_kv, dtype=torch.long)
+
+    q_name = "model.layers.0.self_attn.q_proj.weight"
+    q = out[q_name]
+    out[q_name] = (
+        q.reshape(n_heads, head_dim, -1)
+        .index_select(0, perm_q_t)
+        .reshape(n_heads * head_dim, -1)
+        .contiguous()
+    )
+    for role in ("k_proj", "v_proj"):
+        name = f"model.layers.0.self_attn.{role}.weight"
+        t = out[name]
+        out[name] = (
+            t.reshape(n_kv, head_dim, -1)
+            .index_select(0, perm_kv_t)
+            .reshape(n_kv * head_dim, -1)
+            .contiguous()
+        )
+    o_name = "model.layers.0.self_attn.o_proj.weight"
+    o = out[o_name]
+    out[o_name] = (
+        o.reshape(o.shape[0], n_heads, head_dim)
+        .index_select(1, perm_q_t)
+        .reshape(o.shape[0], n_heads * head_dim)
+        .contiguous()
+    )
+    return out
+
+
+class TestGQAKVPermutation:
+    """Regression coverage for KV-head permutation under GQA/MQA.
+
+    Guards against the KV-head permutation collapsing to the identity,
+    which silently leaves K and V unaligned for grouped-/multi-query
+    models while still reporting ``attention_heads_aligned == n_heads``.
+    """
+
+    def test_gqa_kv_permutation_recovers_alignment(self) -> None:
+        rng = np.random.default_rng(7)
+        hidden, n_heads, n_kv, head_dim = 16, 4, 2, 4
+        cfg_meta = _SynthArchConfig(
+            hidden_size=hidden,
+            num_attention_heads=n_heads,
+            num_key_value_heads=n_kv,
+            head_dim=head_dim,
+            intermediate_size=hidden * 2,
+        )
+        state_a = _make_gqa_attention_layer(rng, hidden, n_heads, n_kv, head_dim)
+
+        # B swaps the two KV groups and the two matching Q groups together,
+        # so the transform is function-preserving and fully recoverable.
+        perm_q = np.array([2, 3, 0, 1], dtype=np.int64)
+        perm_kv = np.array([1, 0], dtype=np.int64)
+        state_b = _permute_gqa_attention_b(
+            state_a, perm_q, perm_kv, head_dim, n_heads, n_kv
+        )
+
+        # Sanity: K is degraded before canonicalization.
+        k_name = "model.layers.0.self_attn.k_proj.weight"
+        raw_k_cos = _vec_cosine(state_a[k_name], state_b[k_name])
+        assert raw_k_cos < 0.95, f"unexpected raw k cosine {raw_k_cos!r}"
+
+        cfg = CanonicalizationConfig(
+            enabled=True,
+            align_permutations=True,
+            normalize_scales=False,
+            method="hungarian",
+        )
+        canonicalizer = WeightCanonicalizer(cfg)
+        view_a, view_b, report = canonicalizer.canonicalize_pair(
+            state_a, state_b, cfg_meta, cfg_meta
+        )
+
+        for role in ("q_proj", "k_proj", "v_proj", "o_proj"):
+            name = f"model.layers.0.self_attn.{role}.weight"
+            cos = _vec_cosine(view_a[name], view_b[name])
+            assert cos > 0.999, f"{role} cosine should approach 1.0 (got {cos:.4f})"
+
+        assert report.attention_heads_aligned == n_heads
+        assert report.unsupported_layers == []
+
+    def test_gqa_group_split_bails_with_unsupported_record(self) -> None:
+        rng = np.random.default_rng(8)
+        hidden, n_heads, n_kv, head_dim = 16, 4, 2, 4
+        cfg_meta = _SynthArchConfig(
+            hidden_size=hidden,
+            num_attention_heads=n_heads,
+            num_key_value_heads=n_kv,
+            head_dim=head_dim,
+            intermediate_size=hidden * 2,
+        )
+        state_a = _make_gqa_attention_layer(rng, hidden, n_heads, n_kv, head_dim)
+
+        # Make both KV groups identical so head assignment is driven purely
+        # by the Q signature: the recovered Q permutation is then exactly
+        # the one applied to B, with no KV signal to mask the incompatibility.
+        for role in ("k_proj", "v_proj"):
+            name = f"model.layers.0.self_attn.{role}.weight"
+            grp = state_a[name][:head_dim].clone()
+            state_a[name] = torch.cat([grp, grp], dim=0).contiguous()
+
+        # perm_q sends A-side group 0 heads {0, 1} to B positions {2, 1},
+        # which fall in different KV groups — an incompatible Q permutation.
+        perm_q = np.array([2, 1, 0, 3], dtype=np.int64)
+        perm_kv = np.array([0, 1], dtype=np.int64)
+        state_b = _permute_gqa_attention_b(
+            state_a, perm_q, perm_kv, head_dim, n_heads, n_kv
+        )
+
+        cfg = CanonicalizationConfig(
+            enabled=True,
+            align_permutations=True,
+            normalize_scales=False,
+            method="hungarian",
+        )
+        canonicalizer = WeightCanonicalizer(cfg)
+        _, _, report = canonicalizer.canonicalize_pair(
+            state_a, state_b, cfg_meta, cfg_meta
+        )
+
+        # The canonicalizer must bail rather than report a false success.
+        assert report.attention_heads_aligned == 0
+        assert report.layers_aligned == 0
+        assert any(
+            entry.endswith(":gqa_group_split") for entry in report.unsupported_layers
+        ), report.unsupported_layers
+
+    def test_mqa_single_kv_group_handles_trivial_permutation(self) -> None:
+        rng = np.random.default_rng(9)
+        hidden, n_heads, n_kv, head_dim = 16, 4, 1, 4
+        cfg_meta = _SynthArchConfig(
+            hidden_size=hidden,
+            num_attention_heads=n_heads,
+            num_key_value_heads=n_kv,
+            head_dim=head_dim,
+            intermediate_size=hidden * 2,
+        )
+        state_a = _make_gqa_attention_layer(rng, hidden, n_heads, n_kv, head_dim)
+
+        # MQA has a single KV group: it cannot be permuted, so K and V are
+        # carried over unchanged while the Q heads are shuffled.
+        perm_q = np.array([1, 2, 3, 0], dtype=np.int64)
+        perm_kv = np.array([0], dtype=np.int64)
+        state_b = _permute_gqa_attention_b(
+            state_a, perm_q, perm_kv, head_dim, n_heads, n_kv
+        )
+
+        cfg = CanonicalizationConfig(
+            enabled=True,
+            align_permutations=True,
+            normalize_scales=False,
+            method="hungarian",
+        )
+        canonicalizer = WeightCanonicalizer(cfg)
+        view_a, view_b, report = canonicalizer.canonicalize_pair(
+            state_a, state_b, cfg_meta, cfg_meta
+        )
+
+        # kv_perm collapses to [0]; K/V stay identical to A's.
+        for role in ("k_proj", "v_proj"):
+            name = f"model.layers.0.self_attn.{role}.weight"
+            cos = _vec_cosine(view_a[name], view_b[name])
+            assert cos > 0.999, f"{role} cosine should approach 1.0 (got {cos:.4f})"
+
+        assert report.attention_heads_aligned == n_heads
+        assert report.unsupported_layers == []

--- a/tests/test_canonicalization.py
+++ b/tests/test_canonicalization.py
@@ -1024,3 +1024,74 @@ class TestFloat32CostMatrix:
             assert cos > 0.999, f"{name} cosine should approach 1.0 (got {cos:.4f})"
         assert report.attention_heads_aligned == n_heads
         assert report.mlp_channels_aligned == intermediate
+
+
+# ── Vectorized greedy fallback coverage (Fix 3) ───────────────────
+
+
+def _naive_greedy(cost: np.ndarray) -> np.ndarray:
+    """Pre-vectorisation greedy: sort ``(cost, row, col)`` tuples ascending.
+
+    This is the reference implementation the vectorized
+    flat-index/argsort path must reproduce byte-for-byte.
+    """
+    n, m = cost.shape
+    triples = [(float(cost[i, j]), i, j) for i in range(n) for j in range(m)]
+    triples.sort()
+    perm = np.full(n, -1, dtype=np.int64)
+    used_cols: set[int] = set()
+    assigned = 0
+    for _, i, j in triples:
+        if perm[i] == -1 and j not in used_cols:
+            perm[i] = j
+            used_cols.add(j)
+            assigned += 1
+            if assigned == n:
+                break
+    return perm
+
+
+class TestVectorizedGreedy:
+    """Lock the vectorized greedy fallback against the naive reference.
+
+    The greedy solver used to materialise an ``(cost, row, col)`` tuple
+    per cell — ~n*m Python objects, which OOMs at LLM MLP widths. The
+    vectorized form sorts flat indices instead. A stable argsort breaks
+    ties by flat index, i.e. lexicographically by ``(row, col)``, which
+    matches the tuple sort exactly, so the recovered permutation must be
+    byte-identical to the naive implementation.
+    """
+
+    @pytest.mark.parametrize("n", [32, 64, 256, 1024])
+    def test_vectorized_matches_naive(self, n: int) -> None:
+        rng = np.random.default_rng(20260519 + n)
+        cost = rng.standard_normal((n, n)).astype(np.float32)
+        vectorized = _solve_assignment(cost, method="greedy")
+        naive = _naive_greedy(cost)
+        _assert_complete_perm(vectorized, n)
+        assert vectorized.tolist() == naive.tolist(), (
+            f"n={n}: vectorized greedy diverged from the naive reference"
+        )
+
+    def test_vectorized_matches_naive_with_heavy_ties(self) -> None:
+        # Integer-valued costs create large blocks of equal cells, which
+        # stresses the stable-sort tie-break that must match the tuple
+        # sort's (cost, row, col) lexicographic ordering.
+        n = 128
+        rng = np.random.default_rng(424242)
+        cost = rng.integers(0, 4, size=(n, n)).astype(np.float32)
+        vectorized = _solve_assignment(cost, method="greedy")
+        naive = _naive_greedy(cost)
+        _assert_complete_perm(vectorized, n)
+        assert vectorized.tolist() == naive.tolist()
+
+    def test_vectorized_recovers_known_permutation(self) -> None:
+        # A cost matrix whose unique minimum-cost assignment is a known
+        # permutation: greedy must recover it.
+        n = 512
+        perm = np.random.default_rng(7).permutation(n)
+        cost = np.full((n, n), 1.0, dtype=np.float32)
+        cost[np.arange(n), perm] = 0.0
+        recovered = _solve_assignment(cost, method="greedy")
+        _assert_complete_perm(recovered, n)
+        assert recovered.tolist() == perm.tolist()

--- a/tests/test_canonicalization.py
+++ b/tests/test_canonicalization.py
@@ -39,11 +39,14 @@ import torch
 
 from provenancekit.cli import main as cli_main
 from provenancekit.core.canonicalization import (
+    _HAS_SCIPY,
     CanonicalizationConfig,
     ComparisonView,
     WeightCanonicalizer,
+    _solve_assignment,
     assert_not_comparison_view,
 )
+from provenancekit.models.results import CanonicalizationReportOutput
 
 # ── Synthetic helpers ─────────────────────────────────────────────
 
@@ -329,7 +332,8 @@ class TestNoOpSafety:
     def test_runtime_guard_rejects_comparison_view(self) -> None:
         state = {"x.weight": torch.randn(4, 4)}
         view = ComparisonView(
-            state, report=WeightCanonicalizer(CanonicalizationConfig()).config  # noqa: SLF001
+            state,
+            report=WeightCanonicalizer(CanonicalizationConfig()).config,  # noqa: SLF001
         )
         # Replace the report with a real one; the guard only checks the marker.
         from provenancekit.core.canonicalization import CanonicalizationReport
@@ -462,3 +466,243 @@ class TestCLIIntegration:
         # And confirm the CLI passed through the canonicalization config.
         call = mock_scanner.return_value.compare.call_args
         assert call.kwargs["canonicalization"].enabled is True
+
+
+def _assert_complete_perm(perm: np.ndarray, n: int) -> None:
+    """Assert ``perm`` is a complete, valid permutation of ``range(n)``."""
+    assert perm.shape == (n,), f"unexpected shape {perm.shape}"
+    assert np.all(perm >= 0), f"perm contains -1 entries: {perm.tolist()}"
+    assert set(perm.tolist()) == set(range(n)), (
+        f"perm is not a valid permutation of 0..{n - 1}: {perm.tolist()}"
+    )
+
+
+class TestGreedyAssignment:
+    """Edge-case coverage for the greedy fallback in ``_solve_assignment``.
+
+    The greedy path used to use ``for _ in range(n)`` and could ``continue``
+    past collisions without making an assignment, leaving ``-1`` entries in
+    the returned permutation. Downstream callers
+    (``_permute_attention_out``, MLP ``index_select``) do not filter ``-1``
+    and would error or produce wrong results. The sorted-pair scan
+    guarantees completeness; these tests lock that contract.
+    """
+
+    @pytest.mark.parametrize(
+        "case_name,cost",
+        [
+            (
+                "all_identical",
+                np.full((6, 6), 0.5, dtype=np.float64),
+            ),
+            (
+                "top1_collision",
+                # Every row's argmin is column 0 — the original collision bug.
+                (lambda n=6: np.full((n, n), 0.5, dtype=np.float64) * 0 + 0.5)(),
+            ),
+            (
+                "all_zero",
+                np.zeros((5, 5), dtype=np.float64),
+            ),
+            (
+                "single_cell",
+                np.array([[0.0]], dtype=np.float64),
+            ),
+            (
+                "negative_costs",
+                # Cost = 1 - cosine: with negative cosines the cost can exceed
+                # 1.0; the algorithm minimises, so very-negative cells aren't
+                # special, but the code must still complete with negatives.
+                np.array(
+                    [
+                        [-0.5, 0.2, 1.5],
+                        [1.2, -0.9, 0.0],
+                        [0.4, 1.8, -0.1],
+                    ],
+                    dtype=np.float64,
+                ),
+            ),
+            (
+                "with_inf",
+                # Inf must sort to the back and be picked last (only when
+                # forced). Completeness must still hold.
+                np.array(
+                    [
+                        [0.1, np.inf, 0.5],
+                        [np.inf, 0.2, 0.3],
+                        [0.4, 0.6, np.inf],
+                    ],
+                    dtype=np.float64,
+                ),
+            ),
+        ],
+    )
+    def test_greedy_assignment_complete(self, case_name: str, cost: np.ndarray) -> None:
+        # Force the top-1 collision by overriding column 0 of all rows.
+        if case_name == "top1_collision":
+            cost = cost.copy()
+            cost[:, 0] = 0.0  # everyone wants column 0 first
+            # Add small differentiation so non-zero columns remain pickable
+            # but with a tie among rows for column 0.
+            rng = np.random.default_rng(0)
+            cost[:, 1:] = rng.uniform(0.4, 0.6, size=(cost.shape[0], cost.shape[1] - 1))
+
+        # ``with_inf`` would be rejected by the new isfinite() guard;
+        # exercise it explicitly to lock that contract and then run the
+        # finite version of the case.
+        if case_name == "with_inf":
+            with pytest.raises(ValueError, match="finite"):
+                _solve_assignment(cost, method="greedy")
+            return
+
+        n = cost.shape[0]
+        perm = _solve_assignment(cost, method="greedy")
+        _assert_complete_perm(perm, n)
+
+        if case_name == "single_cell":
+            assert perm.tolist() == [0]
+
+        if case_name == "top1_collision":
+            # Exactly one row claims column 0 (the universally cheapest).
+            assert int((perm == 0).sum()) == 1
+
+    def test_rectangular_cost_is_rejected(self) -> None:
+        """The function requires a square cost matrix and must raise."""
+        cost = np.zeros((3, 5), dtype=np.float64)
+        with pytest.raises(ValueError, match="square"):
+            _solve_assignment(cost, method="greedy")
+
+    def test_nan_cost_is_rejected(self) -> None:
+        """NaN in cost is rejected with a clear error (locks contract)."""
+        cost = np.array(
+            [[0.1, 0.2], [np.nan, 0.3]],
+            dtype=np.float64,
+        )
+        with pytest.raises(ValueError, match="finite"):
+            _solve_assignment(cost, method="greedy")
+
+    @pytest.mark.skipif(not _HAS_SCIPY, reason="scipy not installed")
+    def test_greedy_matches_hungarian_on_well_separated(self) -> None:
+        """When the optimum is unique by a wide margin, greedy and Hungarian
+        must agree. Catches regressions where greedy goes pathologically
+        wrong on easy inputs."""
+        # Construct a strongly diagonal cost: identity is the unique optimum.
+        n = 8
+        cost = np.full((n, n), 5.0, dtype=np.float64)
+        np.fill_diagonal(cost, 0.0)
+        # Add slight off-diagonal noise so the optimum stays unique.
+        rng = np.random.default_rng(123)
+        cost = cost + rng.uniform(0.0, 0.1, size=(n, n))
+        np.fill_diagonal(cost, 0.0)
+
+        greedy = _solve_assignment(cost, method="greedy")
+        hungarian = _solve_assignment(cost, method="hungarian")
+
+        _assert_complete_perm(greedy, n)
+        _assert_complete_perm(hungarian, n)
+        assert greedy.tolist() == hungarian.tolist()
+        assert greedy.tolist() == list(range(n))
+
+    def test_greedy_random_property_check(self) -> None:
+        """Fuzz the greedy path with random square cost matrices and
+        confirm every returned permutation is valid and complete."""
+        rng = np.random.default_rng(20260511)
+        for _ in range(50):
+            n = int(rng.integers(low=1, high=17))  # n in [1, 16]
+            cost = rng.standard_normal(size=(n, n)).astype(np.float64)
+            perm = _solve_assignment(cost, method="greedy")
+            assert perm.dtype == np.int64
+            _assert_complete_perm(perm, n)
+            # Each column used exactly once.
+            assert len(set(perm.tolist())) == n
+            assert all(0 <= int(p) < n for p in perm)
+
+
+class TestCanonicalizationReportMutableDefaults:
+    """Lock the Field(default_factory=list) fix.
+
+    A previous version used ``list[str] = []`` which is a class-level
+    mutable default — *Pydantic v2 actually copies the default* and is
+    safe in practice, but the class-attribute form is fragile and easy to
+    regress to a shared list under refactors. The Field(default_factory)
+    form makes the intent explicit and gives belt-and-braces independence.
+    """
+
+    def test_default_lists_are_independent(self) -> None:
+        r1 = CanonicalizationReportOutput(
+            enabled=True,
+            method="hungarian",
+            scale_mode="comparison",
+            non_invertible=True,
+        )
+        r2 = CanonicalizationReportOutput(
+            enabled=True,
+            method="hungarian",
+            scale_mode="comparison",
+            non_invertible=True,
+        )
+        # Distinct objects per instance.
+        assert r1.unsupported_layers is not r2.unsupported_layers
+        assert r1.stability_warnings is not r2.stability_warnings
+
+        # Mutating one must not affect the other.
+        r1.unsupported_layers.append("layer.0")
+        r1.stability_warnings.append("warn")
+        assert r2.unsupported_layers == []
+        assert r2.stability_warnings == []
+
+        # And a freshly built third instance must also be empty —
+        # catches a regression where mutation leaks into the class default.
+        r3 = CanonicalizationReportOutput(
+            enabled=True,
+            method="hungarian",
+            scale_mode="comparison",
+            non_invertible=True,
+        )
+        assert r3.unsupported_layers == []
+        assert r3.stability_warnings == []
+
+    def test_model_dump_default_and_populated(self) -> None:
+        r = CanonicalizationReportOutput(
+            enabled=False,
+            method="hungarian",
+            scale_mode="comparison",
+            non_invertible=True,
+        )
+        dumped = r.model_dump()
+        assert dumped["unsupported_layers"] == []
+        assert dumped["stability_warnings"] == []
+
+        r.unsupported_layers.append("attn:layer.0:non_2d")
+        r.stability_warnings.append("layer.0:perm_jump")
+        dumped = r.model_dump()
+        assert dumped["unsupported_layers"] == ["attn:layer.0:non_2d"]
+        assert dumped["stability_warnings"] == ["layer.0:perm_jump"]
+
+        # JSON round-trip preserves both fields.
+        from_json = CanonicalizationReportOutput.model_validate_json(
+            r.model_dump_json()
+        )
+        assert from_json.unsupported_layers == r.unsupported_layers
+        assert from_json.stability_warnings == r.stability_warnings
+
+    def test_explicit_list_inputs_still_supported(self) -> None:
+        r = CanonicalizationReportOutput(
+            enabled=True,
+            method="hungarian",
+            scale_mode="comparison",
+            non_invertible=True,
+            unsupported_layers=["a", "b"],
+            stability_warnings=["w1"],
+        )
+        assert r.unsupported_layers == ["a", "b"]
+        assert r.stability_warnings == ["w1"]
+
+    def test_json_schema_field_types_unchanged(self) -> None:
+        """Schema shape must still report array-of-string for both fields."""
+        schema = CanonicalizationReportOutput.model_json_schema()
+        props = schema["properties"]
+        for name in ("unsupported_layers", "stability_warnings"):
+            field_schema = props[name]
+            assert field_schema["type"] == "array"
+            assert field_schema["items"] == {"type": "string"}

--- a/tests/test_canonicalization.py
+++ b/tests/test_canonicalization.py
@@ -1,0 +1,464 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the canonicalization module.
+
+Synthetic transformer-like state dicts validate:
+
+* attention head permutation is recovered,
+* MLP/neuron permutation is recovered,
+* per-channel scale normalization is invariant to channel rescalings,
+* identical inputs round-trip without crashing,
+* unsupported architectures degrade gracefully,
+* the CLI exposes ``--canonicalize`` in its help text.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+from dataclasses import dataclass
+from io import StringIO
+
+import numpy as np
+import pytest
+import torch
+
+from provenancekit.cli import main as cli_main
+from provenancekit.core.canonicalization import (
+    CanonicalizationConfig,
+    ComparisonView,
+    WeightCanonicalizer,
+    assert_not_comparison_view,
+)
+
+# ── Synthetic helpers ─────────────────────────────────────────────
+
+
+@dataclass
+class _SynthArchConfig:
+    """Minimal AutoConfig stand-in for the canonicalizer."""
+
+    hidden_size: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    intermediate_size: int
+
+
+def _vec_cosine(a: torch.Tensor, b: torch.Tensor) -> float:
+    av = a.flatten().float()
+    bv = b.flatten().float()
+    denom = float(torch.linalg.vector_norm(av) * torch.linalg.vector_norm(bv))
+    if denom < 1e-10:
+        return 0.0
+    return float(torch.dot(av, bv) / denom)
+
+
+def _make_attention_layer(
+    rng: np.random.Generator,
+    hidden: int,
+    n_heads: int,
+    head_dim: int,
+) -> dict[str, torch.Tensor]:
+    """Build q/k/v/o projection weights with realistic shapes."""
+    out_dim = n_heads * head_dim
+    q = torch.tensor(rng.standard_normal((out_dim, hidden)), dtype=torch.float32)
+    k = torch.tensor(rng.standard_normal((out_dim, hidden)), dtype=torch.float32)
+    v = torch.tensor(rng.standard_normal((out_dim, hidden)), dtype=torch.float32)
+    o = torch.tensor(rng.standard_normal((hidden, out_dim)), dtype=torch.float32)
+    return {
+        "model.layers.0.self_attn.q_proj.weight": q,
+        "model.layers.0.self_attn.k_proj.weight": k,
+        "model.layers.0.self_attn.v_proj.weight": v,
+        "model.layers.0.self_attn.o_proj.weight": o,
+    }
+
+
+def _make_mlp_layer(
+    rng: np.random.Generator, hidden: int, intermediate: int
+) -> dict[str, torch.Tensor]:
+    """Build gate/up/down MLP projections (LLaMA-style gated MLP)."""
+    gate = torch.tensor(
+        rng.standard_normal((intermediate, hidden)), dtype=torch.float32
+    )
+    up = torch.tensor(rng.standard_normal((intermediate, hidden)), dtype=torch.float32)
+    down = torch.tensor(
+        rng.standard_normal((hidden, intermediate)), dtype=torch.float32
+    )
+    return {
+        "model.layers.0.mlp.gate_proj.weight": gate,
+        "model.layers.0.mlp.up_proj.weight": up,
+        "model.layers.0.mlp.down_proj.weight": down,
+    }
+
+
+def _permute_attention_b(
+    state: dict[str, torch.Tensor], perm: np.ndarray, head_dim: int, n_heads: int
+) -> dict[str, torch.Tensor]:
+    """Apply a head permutation to a synthetic attention block."""
+    out = dict(state)
+    perm_t = torch.as_tensor(perm, dtype=torch.long)
+    for role in ("q_proj", "k_proj", "v_proj"):
+        name = f"model.layers.0.self_attn.{role}.weight"
+        t = out[name]
+        reshaped = t.reshape(n_heads, head_dim, -1)
+        permuted = reshaped.index_select(0, perm_t)
+        out[name] = permuted.reshape(n_heads * head_dim, -1).contiguous()
+    o_name = "model.layers.0.self_attn.o_proj.weight"
+    o = out[o_name]
+    o_reshaped = o.reshape(o.shape[0], n_heads, head_dim)
+    out[o_name] = (
+        o_reshaped.index_select(1, perm_t)
+        .reshape(o.shape[0], n_heads * head_dim)
+        .contiguous()
+    )
+    return out
+
+
+def _permute_mlp_b(
+    state: dict[str, torch.Tensor], perm: np.ndarray
+) -> dict[str, torch.Tensor]:
+    out = dict(state)
+    perm_t = torch.as_tensor(perm, dtype=torch.long)
+    for role in ("gate_proj", "up_proj"):
+        name = f"model.layers.0.mlp.{role}.weight"
+        t = out[name]
+        out[name] = t.index_select(0, perm_t).contiguous()
+    down_name = "model.layers.0.mlp.down_proj.weight"
+    out[down_name] = out[down_name].index_select(1, perm_t).contiguous()
+    return out
+
+
+# ── Tests ────────────────────────────────────────────────────────
+
+
+class TestHeadPermutationInvariance:
+    def test_alignment_recovers_high_cosine(self) -> None:
+        rng = np.random.default_rng(0)
+        hidden, n_heads, head_dim = 32, 4, 8
+        cfg_meta = _SynthArchConfig(
+            hidden_size=hidden,
+            num_attention_heads=n_heads,
+            num_key_value_heads=n_heads,
+            head_dim=head_dim,
+            intermediate_size=hidden * 2,
+        )
+        state_a = _make_attention_layer(rng, hidden, n_heads, head_dim)
+
+        perm = np.array([2, 0, 3, 1], dtype=np.int64)
+        state_b = _permute_attention_b(state_a, perm, head_dim, n_heads)
+
+        # Sanity: raw cosine is degraded after permutation.
+        q_a = state_a["model.layers.0.self_attn.q_proj.weight"]
+        q_b_raw = state_b["model.layers.0.self_attn.q_proj.weight"]
+        raw_cos = _vec_cosine(q_a, q_b_raw)
+        assert raw_cos < 0.95, f"unexpected raw cosine {raw_cos!r}"
+
+        # Run the canonicalizer with permutation-only (no scale normalization
+        # so the test isolates the alignment step).
+        cfg = CanonicalizationConfig(
+            enabled=True,
+            align_permutations=True,
+            normalize_scales=False,
+            method="hungarian",
+        )
+        canonicalizer = WeightCanonicalizer(cfg)
+        view_a, view_b, report = canonicalizer.canonicalize_pair(
+            state_a, state_b, cfg_meta, cfg_meta
+        )
+
+        q_a_c = view_a["model.layers.0.self_attn.q_proj.weight"]
+        q_b_c = view_b["model.layers.0.self_attn.q_proj.weight"]
+        canon_cos = _vec_cosine(q_a_c, q_b_c)
+
+        assert canon_cos > 0.999, (
+            f"canonicalized cosine should approach 1.0 (got {canon_cos:.4f})"
+        )
+        assert report.attention_heads_aligned == n_heads
+        assert report.layers_aligned == 1
+
+
+class TestMLPNeuronPermutationInvariance:
+    def test_alignment_recovers_high_cosine(self) -> None:
+        rng = np.random.default_rng(1)
+        hidden, intermediate = 16, 64
+        cfg_meta = _SynthArchConfig(
+            hidden_size=hidden,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=hidden // 2,
+            intermediate_size=intermediate,
+        )
+        state_a = _make_mlp_layer(rng, hidden, intermediate)
+
+        perm = np.random.default_rng(7).permutation(intermediate)
+        state_b = _permute_mlp_b(state_a, perm)
+
+        up_a = state_a["model.layers.0.mlp.up_proj.weight"]
+        up_b_raw = state_b["model.layers.0.mlp.up_proj.weight"]
+        raw_cos = _vec_cosine(up_a, up_b_raw)
+        assert raw_cos < 0.5, f"raw permuted cosine should be low ({raw_cos:.3f})"
+
+        cfg = CanonicalizationConfig(
+            enabled=True,
+            align_permutations=True,
+            normalize_scales=False,
+            method="hungarian",
+        )
+        canonicalizer = WeightCanonicalizer(cfg)
+        view_a, view_b, report = canonicalizer.canonicalize_pair(
+            state_a, state_b, cfg_meta, cfg_meta
+        )
+
+        up_a_c = view_a["model.layers.0.mlp.up_proj.weight"]
+        up_b_c = view_b["model.layers.0.mlp.up_proj.weight"]
+        canon_cos = _vec_cosine(up_a_c, up_b_c)
+        assert canon_cos > 0.999, (
+            f"canonicalized MLP cosine should approach 1.0 (got {canon_cos:.4f})"
+        )
+        assert report.mlp_channels_aligned == intermediate
+
+
+class TestScaleNormalization:
+    def test_per_channel_rescale_collapses_to_unit_norm(self) -> None:
+        rng = np.random.default_rng(42)
+        hidden, intermediate = 8, 16
+        state_a = _make_mlp_layer(rng, hidden, intermediate)
+        state_b = {k: v.clone() for k, v in state_a.items()}
+
+        # Rescale a single output channel by 5x in B's up_proj.
+        up_b = state_b["model.layers.0.mlp.up_proj.weight"]
+        up_b[3, :] *= 5.0
+        state_b["model.layers.0.mlp.up_proj.weight"] = up_b
+
+        cfg = CanonicalizationConfig(
+            enabled=True,
+            align_permutations=False,
+            normalize_scales=True,
+            scale_mode="comparison",
+        )
+        canonicalizer = WeightCanonicalizer(cfg)
+        view_a, view_b, report = canonicalizer.canonicalize_pair(
+            state_a, state_b, None, None
+        )
+
+        up_a_c = view_a["model.layers.0.mlp.up_proj.weight"]
+        up_b_c = view_b["model.layers.0.mlp.up_proj.weight"]
+
+        # Each row should be unit-norm now.
+        row_norms_a = torch.linalg.vector_norm(up_a_c, dim=1).numpy()
+        row_norms_b = torch.linalg.vector_norm(up_b_c, dim=1).numpy()
+        assert np.allclose(row_norms_a, 1.0, atol=1e-5)
+        assert np.allclose(row_norms_b, 1.0, atol=1e-5)
+        assert report.scale_normalized is True
+        assert report.non_invertible is True
+
+
+class TestNoOpSafety:
+    def test_identical_inputs_remain_identical(self) -> None:
+        rng = np.random.default_rng(2)
+        hidden, n_heads, head_dim = 16, 2, 8
+        cfg_meta = _SynthArchConfig(
+            hidden_size=hidden,
+            num_attention_heads=n_heads,
+            num_key_value_heads=n_heads,
+            head_dim=head_dim,
+            intermediate_size=hidden * 4,
+        )
+        state_a = _make_attention_layer(rng, hidden, n_heads, head_dim)
+        state_a.update(_make_mlp_layer(rng, hidden, hidden * 4))
+        state_b = {k: v.clone() for k, v in state_a.items()}
+
+        cfg = CanonicalizationConfig(
+            enabled=True, align_permutations=True, normalize_scales=False
+        )
+        canonicalizer = WeightCanonicalizer(cfg)
+        view_a, view_b, _ = canonicalizer.canonicalize_pair(
+            state_a, state_b, cfg_meta, cfg_meta
+        )
+        for name in state_a:
+            assert torch.allclose(view_a[name], view_b[name], atol=1e-6)
+
+    def test_unsupported_architecture_does_not_crash(self) -> None:
+        # A state dict with no recognisable attention / MLP tensors.
+        state_a = {
+            "weird.blob.weight": torch.randn(8, 8),
+            "another.scalar": torch.randn(4),
+        }
+        state_b = {k: v.clone() for k, v in state_a.items()}
+        cfg = CanonicalizationConfig(enabled=True)
+        canonicalizer = WeightCanonicalizer(cfg)
+        view_a, view_b, report = canonicalizer.canonicalize_pair(
+            state_a, state_b, None, None
+        )
+        # Both views are returned; nothing aligned.
+        assert report.attention_heads_aligned == 0
+        assert report.mlp_channels_aligned == 0
+        assert isinstance(view_a, ComparisonView)
+        assert isinstance(view_b, ComparisonView)
+
+    def test_disabled_config_short_circuits(self) -> None:
+        state_a = {"model.layers.0.self_attn.q_proj.weight": torch.randn(8, 8)}
+        state_b = {"model.layers.0.self_attn.q_proj.weight": torch.randn(8, 8)}
+        cfg = CanonicalizationConfig(enabled=False)
+        canonicalizer = WeightCanonicalizer(cfg)
+        view_a, view_b, report = canonicalizer.canonicalize_pair(
+            state_a, state_b, None, None
+        )
+        assert report.enabled is False
+        assert report.skipped_reason == "canonicalization_disabled"
+        assert torch.allclose(
+            view_a["model.layers.0.self_attn.q_proj.weight"],
+            state_a["model.layers.0.self_attn.q_proj.weight"],
+        )
+
+    def test_runtime_guard_rejects_comparison_view(self) -> None:
+        state = {"x.weight": torch.randn(4, 4)}
+        view = ComparisonView(
+            state, report=WeightCanonicalizer(CanonicalizationConfig()).config  # noqa: SLF001
+        )
+        # Replace the report with a real one; the guard only checks the marker.
+        from provenancekit.core.canonicalization import CanonicalizationReport
+
+        view.report = CanonicalizationReport(enabled=True)
+        with pytest.raises(RuntimeError, match="comparison-only"):
+            assert_not_comparison_view(view)
+
+
+class TestCLIIntegration:
+    def test_canonicalize_in_compare_help(self) -> None:
+        old_argv = sys.argv
+        old_stdout = sys.stdout
+        buf = StringIO()
+        try:
+            sys.argv = ["provenancekit", "compare", "--help"]
+            sys.stdout = buf
+            with contextlib.suppress(SystemExit):
+                cli_main()
+        finally:
+            sys.argv = old_argv
+            sys.stdout = old_stdout
+        out = buf.getvalue()
+        assert "--canonicalize" in out
+        assert "comparison-space" in out or "canonicalization" in out
+
+    def test_canonicalize_in_scan_help(self) -> None:
+        old_argv = sys.argv
+        old_stdout = sys.stdout
+        buf = StringIO()
+        try:
+            sys.argv = ["provenancekit", "scan", "--help"]
+            sys.stdout = buf
+            with contextlib.suppress(SystemExit):
+                cli_main()
+        finally:
+            sys.argv = old_argv
+            sys.stdout = old_stdout
+        out = buf.getvalue()
+        assert "--canonicalize" in out
+
+    def test_compare_json_includes_canonicalization_section(self) -> None:
+        # ``compare --canonicalize --json`` must surface the section.
+        import json
+        from unittest.mock import MagicMock, patch
+
+        from provenancekit.models.results import (
+            CanonicalizationReportOutput,
+            CompareResult,
+            PipelineScore,
+            ScoreInterpretation,
+            SignalScores,
+            TimingBreakdown,
+        )
+
+        fake = CompareResult(
+            model_a="x",
+            model_b="y",
+            family_a="x",
+            family_b="y",
+            signals=SignalScores(
+                eas=0.9, nlf=0.9, lep=0.9, end=0.9, wvc=0.9, tfv=0.9, voa=0.9
+            ),
+            scores=PipelineScore(
+                mfi_score=1.0,
+                mfi_tier=1,
+                mfi_match="exact",
+                identity_score=0.9,
+                tokenizer_score=0.9,
+                pipeline_score=1.0,
+                provenance_decision="Confirmed Match",
+            ),
+            interpretation=ScoreInterpretation(label="High", colour="#2ecc71"),
+            time_seconds=1.0,
+            timing=TimingBreakdown(
+                total_seconds=1.0,
+                metadata_extract_seconds=0.5,
+                weight_feature_extract_seconds=0.5,
+                cache_hit="False",
+            ),
+            canonicalization=CanonicalizationReportOutput(
+                enabled=True,
+                method="hungarian",
+                scale_mode="comparison",
+                non_invertible=True,
+                layers_aligned=2,
+                attention_heads_aligned=8,
+                mlp_channels_aligned=64,
+                scale_normalized=True,
+                unsupported_layers=[],
+                stability_warnings=[],
+            ),
+        )
+
+        mock_scanner = MagicMock()
+        mock_scanner.return_value.compare.return_value = fake
+
+        old_argv = sys.argv
+        old_stdout = sys.stdout
+        buf = StringIO()
+        with (
+            patch("provenancekit.core.scanner.ModelProvenanceScanner", mock_scanner),
+            patch("provenancekit.services.cache.CacheService"),
+            patch("provenancekit.cli.Settings"),
+        ):
+            try:
+                sys.argv = [
+                    "provenancekit",
+                    "compare",
+                    "x",
+                    "y",
+                    "--json",
+                    "--canonicalize",
+                ]
+                sys.stdout = buf
+                with contextlib.suppress(SystemExit):
+                    cli_main()
+            finally:
+                sys.argv = old_argv
+                sys.stdout = old_stdout
+
+        data = json.loads(buf.getvalue())
+        canon = data["canonicalization"]
+        assert canon["enabled"] is True
+        assert canon["scale_mode"] == "comparison"
+        assert canon["non_invertible"] is True
+        assert canon["attention_heads_aligned"] == 8
+        assert canon["mlp_channels_aligned"] == 64
+
+        # And confirm the CLI passed through the canonicalization config.
+        call = mock_scanner.return_value.compare.call_args
+        assert call.kwargs["canonicalization"].enabled is True

--- a/tests/test_canonicalization.py
+++ b/tests/test_canonicalization.py
@@ -43,6 +43,7 @@ from provenancekit.core.canonicalization import (
     CanonicalizationConfig,
     ComparisonView,
     WeightCanonicalizer,
+    _build_cost_matrix,
     _solve_assignment,
     assert_not_comparison_view,
 )
@@ -930,3 +931,96 @@ class TestGQAKVPermutation:
 
         assert report.attention_heads_aligned == n_heads
         assert report.unsupported_layers == []
+
+
+# ── Float32 cost-matrix coverage (Fix 2) ──────────────────────────
+
+
+def _cosine_distance_float64(sigs_a: np.ndarray, sigs_b: np.ndarray) -> np.ndarray:
+    """Reference ``1 - cosine`` cost matrix computed entirely in float64."""
+    a = sigs_a.astype(np.float64)
+    b = sigs_b.astype(np.float64)
+    a_unit = a / (np.linalg.norm(a, axis=1, keepdims=True) + 1e-12)
+    b_unit = b / (np.linalg.norm(b, axis=1, keepdims=True) + 1e-12)
+    return 1.0 - a_unit @ b_unit.T
+
+
+class TestFloat32CostMatrix:
+    """Lock the float32 cost-matrix optimisation.
+
+    ``_build_cost_matrix`` used to materialise the assignment cost in the
+    NumPy-default float64. On LLM-width MLP layers that O(n*m) matrix
+    dominates peak memory; building it in float32 halves it. These tests
+    confirm the dtype change and that the precision loss does not move
+    the recovered assignment.
+    """
+
+    def test_cost_matrix_dtype_is_float32(self) -> None:
+        rng = np.random.default_rng(11)
+        sigs_a = rng.standard_normal((24, 40)).astype(np.float32)
+        sigs_b = rng.standard_normal((24, 40)).astype(np.float32)
+        cost = _build_cost_matrix(sigs_a, sigs_b)
+        assert cost.dtype == np.float32
+
+    def test_cost_matrix_matches_float64_reference(self) -> None:
+        rng = np.random.default_rng(12)
+        sigs_a = rng.standard_normal((32, 64)).astype(np.float32)
+        sigs_b = rng.standard_normal((32, 64)).astype(np.float32)
+        cost32 = _build_cost_matrix(sigs_a, sigs_b)
+        ref = _cosine_distance_float64(sigs_a, sigs_b)
+        # float32 cosine distance tracks the float64 reference tightly.
+        assert np.allclose(cost32, ref, atol=1e-4, rtol=0.0)
+
+    def test_recovered_permutation_matches_float64(self) -> None:
+        # A permuted copy of A: the unique optimal assignment is the
+        # inverse permutation. float32 and float64 cost must agree on it.
+        rng = np.random.default_rng(13)
+        n = 96
+        sigs_a = rng.standard_normal((n, 128)).astype(np.float32)
+        shuffle = rng.permutation(n)
+        sigs_b = sigs_a[shuffle].copy()
+
+        cost32 = _build_cost_matrix(sigs_a, sigs_b)
+        cost64 = _cosine_distance_float64(sigs_a, sigs_b)
+
+        for method in ("hungarian", "greedy"):
+            perm32 = _solve_assignment(cost32, method=method)
+            perm64 = _solve_assignment(cost64, method=method)
+            assert perm32.tolist() == perm64.tolist(), (
+                f"{method}: float32 cost changed the recovered permutation"
+            )
+
+    def test_alignment_quality_preserved_on_fixtures(self) -> None:
+        # End-to-end on the existing synthetic fixtures: the float32 cost
+        # path must still recover near-perfect alignment.
+        rng = np.random.default_rng(14)
+        hidden, n_heads, head_dim, intermediate = 32, 4, 8, 128
+        cfg_meta = _SynthArchConfig(
+            hidden_size=hidden,
+            num_attention_heads=n_heads,
+            num_key_value_heads=n_heads,
+            head_dim=head_dim,
+            intermediate_size=intermediate,
+        )
+        state_a = _make_attention_layer(rng, hidden, n_heads, head_dim)
+        state_a.update(_make_mlp_layer(rng, hidden, intermediate))
+
+        attn_perm = np.array([2, 0, 3, 1], dtype=np.int64)
+        state_b = _permute_attention_b(state_a, attn_perm, head_dim, n_heads)
+        mlp_perm = np.random.default_rng(15).permutation(intermediate)
+        state_b = _permute_mlp_b(state_b, mlp_perm)
+
+        cfg = CanonicalizationConfig(
+            enabled=True,
+            align_permutations=True,
+            normalize_scales=False,
+            method="hungarian",
+        )
+        view_a, view_b, report = WeightCanonicalizer(cfg).canonicalize_pair(
+            state_a, state_b, cfg_meta, cfg_meta
+        )
+        for name in state_a:
+            cos = _vec_cosine(view_a[name], view_b[name])
+            assert cos > 0.999, f"{name} cosine should approach 1.0 (got {cos:.4f})"
+        assert report.attention_heads_aligned == n_heads
+        assert report.mlp_channels_aligned == intermediate


### PR DESCRIPTION
Adds an optional canonicalization pass for weight-space provenance signals to reduce false negatives from transformer permutation and scale symmetries. The pass aligns attention heads and MLP channels where architecture metadata permits, normalizes scale-sensitive channels, preserves default behavior, and reports canonicalization metadata in JSON output.